### PR TITLE
refactor: remove error-prone fix_indent

### DIFF
--- a/boot/snapshot/moonlex.js
+++ b/boot/snapshot/moonlex.js
@@ -4971,21 +4971,21 @@ function moonbitlang$core$option$$Option$unwrap$64$(self) {
     return _x;
   }
 }
-function moonbitlang$core$option$$Option$unwrap$4$(self) {
-  if (self === undefined) {
-    return $panic();
-  } else {
-    const _Some = self;
-    const _x = _Some;
-    return _x;
-  }
-}
 function moonbitlang$core$option$$Option$unwrap$110$(self) {
   if (self.$tag === 0) {
     return $panic();
   } else {
     const _Some = self;
     const _x = _Some._0;
+    return _x;
+  }
+}
+function moonbitlang$core$option$$Option$unwrap$4$(self) {
+  if (self === undefined) {
+    return $panic();
+  } else {
+    const _Some = self;
+    const _x = _Some;
     return _x;
   }
 }
@@ -6508,23 +6508,6 @@ function moonbitlang$core$array$$Array$split_at$77$(self, index) {
     moonbitlang$core$builtin$$UninitializedArray$unsafe_blit$77$(v2, 0, self, index, self.length - index | 0);
   }
   return { _0: v1, _1: v2 };
-}
-function moonbitlang$core$array$$Array$contains$5$(self, value) {
-  const _len = self.length;
-  let _tmp = 0;
-  while (true) {
-    const _i = _tmp;
-    if (_i < _len) {
-      const v = self[_i];
-      if (v === value) {
-        return true;
-      }
-      _tmp = _i + 1 | 0;
-      continue;
-    } else {
-      return false;
-    }
-  }
 }
 function moonbitlang$core$array$$Array$flatten$4$(self) {
   let len = 0;
@@ -9645,9 +9628,9 @@ function moonbitlang$lex$lib$codegen$internal$codeblock_parser$$parse_codeblock(
   return subst;
 }
 function moonbitlang$lex$lib$codegen$$group_trans$46$42$func$152$(_env, _p) {
-  const _x = _env._2;
+  const action = _env._2;
   const _bind = _env._1;
-  const action = _env._0;
+  const _x = _env._0;
   return _bind((_p$2) => {
     const _x$2 = _p$2._0;
     const _x$3 = _p$2._1;
@@ -9707,7 +9690,7 @@ function moonbitlang$lex$lib$codegen$$group_trans(trans) {
     const _x$2 = _p$2._1;
     const action = moonbitlang$core$option$$Option$unwrap$110$(moonbitlang$core$builtin$$Map$op_get$97$(tag_action_by_state, _x));
     const _bind$2 = moonbitlang$lex$lib$util$eof_char_set$$EofCharSet$iter_ranges(_x$2);
-    const _env = { _0: action, _1: _bind$2, _2: _x };
+    const _env = { _0: _x, _1: _bind$2, _2: action };
     return moonbitlang$lex$lib$codegen$$group_trans$46$42$func$152$(_env, _p);
   }));
   moonbitlang$core$array$$Array$sort$13$(result);
@@ -9887,10 +9870,10 @@ function moonbitlang$lex$lib$codegen$$codegen_rule(rule) {
   const _tmp$8 = moonbitlang$core$string$$String$concat(_lhs, ", ");
   const _lhs$2 = [_tmp$7, _tmp$8, ")", "->", rule.return_type, "{"];
   const _tmp$9 = moonbitlang$core$string$$String$concat(_lhs$2, " ");
-  const _lhs$3 = moonbitlang$core$array$$Array$flatten$4$([[`match ${moonbitlang$core$builtin$$Show$to_string$4$(engine)}.run(lexbuf) {`], moonbitlang$core$array$$Array$makei$4$(dfa.code_blocks.length, (i) => {
+  const _lhs$3 = moonbitlang$core$array$$Array$flatten$4$([[`  match ${moonbitlang$core$builtin$$Show$to_string$4$(engine)}.run(lexbuf) {`], moonbitlang$core$array$$Array$makei$4$(dfa.code_blocks.length, (i) => {
     const codeblock = moonbitlang$core$array$$Array$op_get$4$(dfa.code_blocks, i);
     const subst = moonbitlang$lex$lib$codegen$internal$codeblock_parser$$parse_codeblock(codeblock);
-    const _lhs$4 = moonbitlang$core$array$$Array$flatten$4$([[`(${moonbitlang$core$builtin$$Show$to_string$9$(i)}, __mbtlex_captures) => {`], moonbitlang$core$array$$Array$mapi$140$(moonbitlang$core$array$$Array$op_get$89$(dfa.captures, i), (i$2, name) => {
+    const _lhs$4 = moonbitlang$core$array$$Array$flatten$4$([[`    (${moonbitlang$core$builtin$$Show$to_string$9$(i)}, __mbtlex_captures) => {`], moonbitlang$core$array$$Array$mapi$140$(moonbitlang$core$array$$Array$op_get$89$(dfa.captures, i), (i$2, name) => {
       let inject_ignore;
       let _tmp$10;
       let _return_value;
@@ -9937,91 +9920,19 @@ function moonbitlang$lex$lib$codegen$$codegen_rule(rule) {
       } else {
         inject_ignore = "";
       }
-      return `let (_start_pos_of_${moonbitlang$core$builtin$$Show$to_string$4$(name)}, _end_pos_of_${moonbitlang$core$builtin$$Show$to_string$4$(name)}) = __mbtlex_captures[${moonbitlang$core$builtin$$Show$to_string$9$(i$2)}]\nlet ${moonbitlang$core$builtin$$Show$to_string$4$(name)}: String = lexbuf.substring(_start_pos_of_${moonbitlang$core$builtin$$Show$to_string$4$(name)}, _end_pos_of_${moonbitlang$core$builtin$$Show$to_string$4$(name)})\n${moonbitlang$core$builtin$$Show$to_string$4$(inject_ignore)}`;
-    }), [moonbitlang$lex$lib$codegen$$rewrite_codeblock(codeblock, subst)], ["}"]]);
+      return `  let (_start_pos_of_${moonbitlang$core$builtin$$Show$to_string$4$(name)}, _end_pos_of_${moonbitlang$core$builtin$$Show$to_string$4$(name)}) = __mbtlex_captures[${moonbitlang$core$builtin$$Show$to_string$9$(i$2)}]\n  let ${moonbitlang$core$builtin$$Show$to_string$4$(name)}: String = lexbuf.substring(_start_pos_of_${moonbitlang$core$builtin$$Show$to_string$4$(name)}, _end_pos_of_${moonbitlang$core$builtin$$Show$to_string$4$(name)})\n  ${moonbitlang$core$builtin$$Show$to_string$4$(inject_ignore)}`;
+    }), [moonbitlang$lex$lib$codegen$$rewrite_codeblock(codeblock, subst)], ["    }"]]);
     return moonbitlang$core$string$$String$concat(_lhs$4, "\n");
-  }), ["_ => abort(\"lex: fail to match\")"], ["}"]]);
+  }), ["    _ => abort(\"lex: fail to match\")"], ["  }"]]);
   const _lhs$4 = [_tmp$3, _tmp$4, _tmp$5, _tmp$6, _tmp$9, moonbitlang$core$string$$String$concat(_lhs$3, "\n"), "}"];
   return moonbitlang$core$string$$String$concat(_lhs$4, "\n");
-}
-function moonbitlang$lex$lib$codegen$$fix_indent(code) {
-  const code$2 = `\n${code}`;
-  let ptr = 0;
-  let indent_count = 0;
-  const buf = moonbitlang$core$builtin$$StringBuilder$new(code$2.length);
-  while (true) {
-    if (ptr < code$2.length) {
-      const ch = code$2.charCodeAt(ptr);
-      ptr = ptr + 1 | 0;
-      moonbitlang$core$builtin$$Logger$write_char$3$(buf, ch);
-      switch (ch) {
-        case 10: {
-          if (indent_count === 0) {
-            while (true) {
-              if (ptr < code$2.length && moonbitlang$core$array$$Array$contains$5$([9, 32], code$2.charCodeAt(ptr))) {
-                ptr = ptr + 1 | 0;
-                continue;
-              } else {
-                break;
-              }
-            }
-          } else {
-            moonbitlang$core$builtin$$Logger$write_char$3$(buf, 32);
-          }
-          break;
-        }
-        case 123: {
-          indent_count = indent_count + 1 | 0;
-          break;
-        }
-        case 125: {
-          indent_count = indent_count - 1 | 0;
-          break;
-        }
-        case 92: {
-          if (ptr < code$2.length) {
-            moonbitlang$core$builtin$$Logger$write_char$3$(buf, code$2.charCodeAt(ptr));
-            ptr = ptr + 1 | 0;
-          }
-          break;
-        }
-        case 34: {
-          while (true) {
-            if (ptr < code$2.length) {
-              const ch$2 = code$2.charCodeAt(ptr);
-              moonbitlang$core$builtin$$Logger$write_char$3$(buf, code$2.charCodeAt(ptr));
-              if (code$2.charCodeAt(ptr) === 92) {
-                if ((ptr + 1 | 0) < code$2.length) {
-                  moonbitlang$core$builtin$$Logger$write_char$3$(buf, code$2.charCodeAt(ptr + 1 | 0));
-                }
-                ptr = ptr + 2 | 0;
-              } else {
-                ptr = ptr + 1 | 0;
-              }
-              if (ch$2 === 34) {
-                break;
-              }
-              continue;
-            } else {
-              break;
-            }
-          }
-          break;
-        }
-      }
-      continue;
-    } else {
-      break;
-    }
-  }
-  return moonbitlang$core$builtin$$StringBuilder$to_string(buf);
 }
 function moonbitlang$lex$lib$codegen$$codegen_lex(lex) {
   const _tmp = lex.header;
   const _lhs = moonbitlang$core$array$$Array$map$131$(lex.rules, moonbitlang$lex$lib$codegen$$codegen_rule);
   const _tmp$2 = moonbitlang$core$string$$String$concat(_lhs, "\n");
   const _lhs$2 = [moonbitlang$lex$lib$codegen$$runtime, _tmp, _tmp$2, lex.trailer];
-  return moonbitlang$lex$lib$codegen$$fix_indent(moonbitlang$core$string$$String$concat(_lhs$2, "\n\n"));
+  return moonbitlang$core$string$$String$concat(_lhs$2, "\n\n");
 }
 function Yoorkin$trie$$T$lookup$154$(self, path) {
   const _bind = moonbitlang$core$string$$String$to_array(path);
@@ -10053,9 +9964,9 @@ function Yoorkin$trie$$T$lookup$154$(self, path) {
 }
 function Yoorkin$trie$$T$add$154$(self, path, value) {
   const _bind = moonbitlang$core$string$$String$to_array(path);
-  return Yoorkin$trie$$add$46$aux$47$3886(value, { buf: _bind, start: 0, len: _bind.length }, self);
+  return Yoorkin$trie$$add$46$aux$47$3870(value, { buf: _bind, start: 0, len: _bind.length }, self);
 }
-function Yoorkin$trie$$add$46$aux$47$3886(value, _param1, _param2) {
+function Yoorkin$trie$$add$46$aux$47$3870(value, _param1, _param2) {
   if (_param1.len === 0) {
     return { value: value, forks: _param2.forks };
   } else {
@@ -10065,7 +9976,7 @@ function Yoorkin$trie$$add$46$aux$47$3886(value, _param1, _param2) {
     const _some = _param1.len - 0 | 0;
     const _x$2 = { buf: _tmp, start: _tmp$2, len: _some - 1 | 0 };
     const subtree = moonbitlang$core$option$$Option$or$51$(moonbitlang$core$immut$sorted_map$$T$op_get$29$(_param2.forks, _x), { value: undefined, forks: moonbitlang$core$immut$sorted_map$$new$29$() });
-    return { value: _param2.value, forks: moonbitlang$core$immut$sorted_map$$T$add$29$(_param2.forks, _x, Yoorkin$trie$$add$46$aux$47$3886(value, _x$2, subtree)) };
+    return { value: _param2.value, forks: moonbitlang$core$immut$sorted_map$$T$add$29$(_param2.forks, _x, Yoorkin$trie$$add$46$aux$47$3870(value, _x$2, subtree)) };
   }
 }
 function Yoorkin$trie$$empty$154$() {

--- a/src/lib/codegen/codegen.mbt
+++ b/src/lib/codegen/codegen.mbt
@@ -7,7 +7,6 @@ pub fn codegen_lex(lex : Lex) -> String {
     lex.trailer,
   ]
   |> String::concat(separator="\n\n")
-  |> fix_indent
 }
 
 ///|
@@ -204,7 +203,7 @@ fn codegen_rule(rule : Rule) -> String {
     ]
     |> String::concat(separator=" "),
     [
-      ["match \{engine}.run(lexbuf) {"],
+      ["  match \{engine}.run(lexbuf) {"],
       Array::makei(dfa.code_blocks.length(), fn(i) {
         let codeblock = dfa.code_blocks[i]
         let subst = @codeblock_parser.parse_codeblock(codeblock)
@@ -218,81 +217,29 @@ fn codegen_rule(rule : Rule) -> String {
         }
 
         [
-          ["(\{i}, __mbtlex_captures) => {"],
+          ["    (\{i}, __mbtlex_captures) => {"],
           dfa.captures[i].mapi(fn(i, name) {
             let inject_ignore = if name_used_in_subst(name) {
               "ignore(\{name})"
             } else {
               ""
             }
-            $|let (_start_pos_of_\{name}, _end_pos_of_\{name}) = __mbtlex_captures[\{i}]
-            $|let \{name}: String = lexbuf.substring(_start_pos_of_\{name}, _end_pos_of_\{name})
-            $|\{inject_ignore}
+            $|  let (_start_pos_of_\{name}, _end_pos_of_\{name}) = __mbtlex_captures[\{i}]
+            $|  let \{name}: String = lexbuf.substring(_start_pos_of_\{name}, _end_pos_of_\{name})
+            $|  \{inject_ignore}
           }),
           [rewrite_codeblock(codeblock, subst)],
-          ["}"],
+          ["    }"],
         ]
         |> Array::flatten()
         |> String::concat(separator="\n")
       }),
-      ["_ => abort(\"lex: fail to match\")"],
-      ["}"],
+      ["    _ => abort(\"lex: fail to match\")"],
+      ["  }"],
     ]
     |> Array::flatten()
     |> String::concat(separator="\n"),
     "}",
   ]
   |> String::concat(separator="\n")
-}
-
-///|
-fn fix_indent(code : String) -> String {
-  // fix indent for the generated code
-  // since moonbit require the toplevel definition at the head of line 
-  // and the others not
-
-  let code = "\n" + code
-  let mut ptr = 0
-  let mut indent_count = 0
-  let buf = StringBuilder::new(size_hint=code.length())
-  while ptr < code.length() {
-    let ch = code[ptr]
-    ptr += 1
-    buf.write_char(ch)
-    match ch {
-      '\n' =>
-        if indent_count == 0 {
-          while ptr < code.length() && ['\t', ' '].contains(code.get(ptr)) {
-            ptr += 1
-          }
-        } else {
-          buf.write_char(' ')
-        }
-      '{' => indent_count += 1
-      '}' => indent_count -= 1
-      '\\' =>
-        if ptr < code.length() {
-          buf.write_char(code.get(ptr))
-          ptr += 1
-        }
-      '\"' =>
-        while ptr < code.length() {
-          let ch = code.get(ptr)
-          buf.write_char(code.get(ptr))
-          if code.get(ptr) == '\\' {
-            if ptr + 1 < code.length() {
-              buf.write_char(code.get(ptr + 1))
-            }
-            ptr += 2
-          } else {
-            ptr += 1
-          }
-          if ch == '\"' {
-            break
-          }
-        }
-      _ => ()
-    }
-  }
-  buf.to_string()
 }

--- a/src/lib/codegen/internal/codeblock_parser/codeblock_parser.mbt
+++ b/src/lib/codegen/internal/codeblock_parser/codeblock_parser.mbt
@@ -1,31 +1,30 @@
-
 ///|
 struct Lexbuf {
-   content : String
-   mut pos : Int
- }
+  content : String
+  mut pos : Int
+}
 
 ///|
 pub fn Lexbuf::from_string(content : String) -> Lexbuf {
-   { content, pos: 0 }
- }
+  { content, pos: 0 }
+}
 
 // NOTE: MoonBit do have unboxed Option[Char] optimization
 ///|
 fn next(self : Lexbuf) -> Char? {
-   if self.pos < self.content.length() {
-     let ch = self.content[self.pos]
-     self.pos += 1
-     Some(ch)
-   } else {
-     None
-   }
- }
+  if self.pos < self.content.length() {
+    let ch = self.content[self.pos]
+    self.pos += 1
+    Some(ch)
+  } else {
+    None
+  }
+}
 
 ///|
 fn substring(self : Lexbuf, start : Int, end : Int) -> String {
-   self.content.substring(start~, end~)
- }
+  self.content.substring(start~, end~)
+}
 
 ///|
 typealias LexTagAction = Array[Array[Int]]
@@ -38,76 +37,76 @@ typealias LexInput = Int
 
 ///|
 pub(all) struct LexEngine {
-   graph : Array[(LexState) -> (LexState, LexTagAction)]
-   end_nodes : Array[(Int, Array[((Int, Int), (Int, Int))])?]
-   start_tags : Array[Int]
-   code_blocks_n : Int
- }
+  graph : Array[(LexState) -> (LexState, LexTagAction)]
+  end_nodes : Array[(Int, Array[((Int, Int), (Int, Int))])?]
+  start_tags : Array[Int]
+  code_blocks_n : Int
+}
 
 ///|
 pub fn run(self : LexEngine, lexbuf : Lexbuf) -> (Int, Array[(Int, Int)]) {
-   let mut state = 0
-   let mut tagState : Array[Array[Int]] = []
-   let backtrace = Array::make(self.code_blocks_n, None)
-   for tag in self.start_tags {
-     while tagState.length() <= tag {
-       tagState.push([])
-     }
-     tagState[tag].push(lexbuf.pos)
-   }
-   while state != -1 {
-     match self.end_nodes[state] {
-       Some(t) => backtrace[t.0] = Some((lexbuf.pos, state, tagState))
-       _ => ()
-     }
-     let b = match lexbuf.next() {
-       Some(b) => b.to_int()
-       None => -1
-     }
-     let next = self.graph[state](b)
-     state = next.0
-     let new_tagState : Array[Array[Int]] = []
-     for i = 0; i < next.1.length(); i = i + 1 {
-       new_tagState.push([])
-       for j = 0; j < next.1[i].length(); j = j + 1 {
-         let t = next.1[i][j]
-         if t == -1 {
-           new_tagState[i].push(lexbuf.pos)
-         } else {
-           new_tagState[i].push(tagState[i][t])
-         }
-       }
-     }
-     tagState = new_tagState
-   }
-   for index, b in backtrace {
-     match b {
-       Some((p, state, tagState)) => {
-         lexbuf.pos = p
-         let captures = self.end_nodes[state].unwrap().1.map(fn {
-           ((b_t, b_r), (e_t, e_r)) => (tagState[b_t][b_r], tagState[e_t][e_r])
-         })
-         break (index, captures)
-       }
-       None => ()
-     }
-   } else {
-     (self.code_blocks_n, [])
-   }
- }
+  let mut state = 0
+  let mut tagState : Array[Array[Int]] = []
+  let backtrace = Array::make(self.code_blocks_n, None)
+  for tag in self.start_tags {
+    while tagState.length() <= tag {
+      tagState.push([])
+    }
+    tagState[tag].push(lexbuf.pos)
+  }
+  while state != -1 {
+    match self.end_nodes[state] {
+      Some(t) => backtrace[t.0] = Some((lexbuf.pos, state, tagState))
+      _ => ()
+    }
+    let b = match lexbuf.next() {
+      Some(b) => b.to_int()
+      None => -1
+    }
+    let next = self.graph[state](b)
+    state = next.0
+    let new_tagState : Array[Array[Int]] = []
+    for i = 0; i < next.1.length(); i = i + 1 {
+      new_tagState.push([])
+      for j = 0; j < next.1[i].length(); j = j + 1 {
+        let t = next.1[i][j]
+        if t == -1 {
+          new_tagState[i].push(lexbuf.pos)
+        } else {
+          new_tagState[i].push(tagState[i][t])
+        }
+      }
+    }
+    tagState = new_tagState
+  }
+  for index, b in backtrace {
+    match b {
+      Some((p, state, tagState)) => {
+        lexbuf.pos = p
+        let captures = self.end_nodes[state].unwrap().1.map(fn {
+          ((b_t, b_r), (e_t, e_r)) => (tagState[b_t][b_r], tagState[e_t][e_r])
+        })
+        break (index, captures)
+      }
+      None => ()
+    }
+  } else {
+    (self.code_blocks_n, [])
+  }
+}
 
 
 
 pub(all) enum SubstItemDesc {
-   StartPosOf(String)
-   EndPosOf(String)
- }
+  StartPosOf(String)
+  EndPosOf(String)
+}
 
 pub(all) struct SubstItem {
-   start : Int
-   end : Int
-   desc : SubstItemDesc
- }
+  start : Int
+  end : Int
+  desc : SubstItemDesc
+}
 
 
 let scan_codeblock_rbrace_tag_action_row_0 : Array[Int] = []
@@ -124,325 +123,325 @@ let scan_codeblock_rbrace_tag_action_6 : Array[Array[Int]] = [scan_codeblock_rbr
 let scan_codeblock_rbrace_tag_action_7 : Array[Array[Int]] = [scan_codeblock_rbrace_tag_action_row_1, scan_codeblock_rbrace_tag_action_row_2, scan_codeblock_rbrace_tag_action_row_1, scan_codeblock_rbrace_tag_action_row_1, scan_codeblock_rbrace_tag_action_row_1, scan_codeblock_rbrace_tag_action_row_1]
 
 fn scan_codeblock_rbrace_state_0(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     0..=35 => (1, scan_codeblock_rbrace_tag_action_0)
-     36 => (2, scan_codeblock_rbrace_tag_action_1)
-     37..=122 => (1, scan_codeblock_rbrace_tag_action_0)
-     123 => (4, scan_codeblock_rbrace_tag_action_0)
-     124 => (1, scan_codeblock_rbrace_tag_action_0)
-     125 => (3, scan_codeblock_rbrace_tag_action_0)
-     126..=1114111 => (1, scan_codeblock_rbrace_tag_action_0)
-     _ => (-1, [])
-   }
- }
+  match input {
+    0..=35 => (1, scan_codeblock_rbrace_tag_action_0)
+    36 => (2, scan_codeblock_rbrace_tag_action_1)
+    37..=122 => (1, scan_codeblock_rbrace_tag_action_0)
+    123 => (4, scan_codeblock_rbrace_tag_action_0)
+    124 => (1, scan_codeblock_rbrace_tag_action_0)
+    125 => (3, scan_codeblock_rbrace_tag_action_0)
+    126..=1114111 => (1, scan_codeblock_rbrace_tag_action_0)
+    _ => (-1, [])
+  }
+}
 fn scan_codeblock_rbrace_state_1(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     _ => (-1, [])
-   }
- }
+  match input {
+    _ => (-1, [])
+  }
+}
 fn scan_codeblock_rbrace_state_2(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     65..=90 => (5, scan_codeblock_rbrace_tag_action_0)
-     95 => (5, scan_codeblock_rbrace_tag_action_0)
-     97..=100 => (5, scan_codeblock_rbrace_tag_action_0)
-     101 => (6, scan_codeblock_rbrace_tag_action_2)
-     102..=114 => (5, scan_codeblock_rbrace_tag_action_0)
-     115 => (7, scan_codeblock_rbrace_tag_action_2)
-     116..=122 => (5, scan_codeblock_rbrace_tag_action_0)
-     _ => (-1, [])
-   }
- }
+  match input {
+    65..=90 => (5, scan_codeblock_rbrace_tag_action_0)
+    95 => (5, scan_codeblock_rbrace_tag_action_0)
+    97..=100 => (5, scan_codeblock_rbrace_tag_action_0)
+    101 => (6, scan_codeblock_rbrace_tag_action_2)
+    102..=114 => (5, scan_codeblock_rbrace_tag_action_0)
+    115 => (7, scan_codeblock_rbrace_tag_action_2)
+    116..=122 => (5, scan_codeblock_rbrace_tag_action_0)
+    _ => (-1, [])
+  }
+}
 fn scan_codeblock_rbrace_state_3(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     _ => (-1, [])
-   }
- }
+  match input {
+    _ => (-1, [])
+  }
+}
 fn scan_codeblock_rbrace_state_4(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     _ => (-1, [])
-   }
- }
+  match input {
+    _ => (-1, [])
+  }
+}
 fn scan_codeblock_rbrace_state_5(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     48..=57 => (8, scan_codeblock_rbrace_tag_action_0)
-     65..=90 => (8, scan_codeblock_rbrace_tag_action_0)
-     95 => (8, scan_codeblock_rbrace_tag_action_0)
-     97..=122 => (8, scan_codeblock_rbrace_tag_action_0)
-     _ => (-1, [])
-   }
- }
+  match input {
+    48..=57 => (8, scan_codeblock_rbrace_tag_action_0)
+    65..=90 => (8, scan_codeblock_rbrace_tag_action_0)
+    95 => (8, scan_codeblock_rbrace_tag_action_0)
+    97..=122 => (8, scan_codeblock_rbrace_tag_action_0)
+    _ => (-1, [])
+  }
+}
 fn scan_codeblock_rbrace_state_6(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     48..=57 => (8, scan_codeblock_rbrace_tag_action_0)
-     65..=90 => (8, scan_codeblock_rbrace_tag_action_0)
-     95 => (8, scan_codeblock_rbrace_tag_action_0)
-     97..=109 => (8, scan_codeblock_rbrace_tag_action_0)
-     110 => (9, scan_codeblock_rbrace_tag_action_2)
-     111..=122 => (8, scan_codeblock_rbrace_tag_action_0)
-     _ => (-1, [])
-   }
- }
+  match input {
+    48..=57 => (8, scan_codeblock_rbrace_tag_action_0)
+    65..=90 => (8, scan_codeblock_rbrace_tag_action_0)
+    95 => (8, scan_codeblock_rbrace_tag_action_0)
+    97..=109 => (8, scan_codeblock_rbrace_tag_action_0)
+    110 => (9, scan_codeblock_rbrace_tag_action_2)
+    111..=122 => (8, scan_codeblock_rbrace_tag_action_0)
+    _ => (-1, [])
+  }
+}
 fn scan_codeblock_rbrace_state_7(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     48..=57 => (8, scan_codeblock_rbrace_tag_action_0)
-     65..=90 => (8, scan_codeblock_rbrace_tag_action_0)
-     95 => (8, scan_codeblock_rbrace_tag_action_0)
-     97..=115 => (8, scan_codeblock_rbrace_tag_action_0)
-     116 => (10, scan_codeblock_rbrace_tag_action_2)
-     117..=122 => (8, scan_codeblock_rbrace_tag_action_0)
-     _ => (-1, [])
-   }
- }
+  match input {
+    48..=57 => (8, scan_codeblock_rbrace_tag_action_0)
+    65..=90 => (8, scan_codeblock_rbrace_tag_action_0)
+    95 => (8, scan_codeblock_rbrace_tag_action_0)
+    97..=115 => (8, scan_codeblock_rbrace_tag_action_0)
+    116 => (10, scan_codeblock_rbrace_tag_action_2)
+    117..=122 => (8, scan_codeblock_rbrace_tag_action_0)
+    _ => (-1, [])
+  }
+}
 fn scan_codeblock_rbrace_state_8(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     48..=57 => (8, scan_codeblock_rbrace_tag_action_0)
-     65..=90 => (8, scan_codeblock_rbrace_tag_action_0)
-     95 => (8, scan_codeblock_rbrace_tag_action_0)
-     97..=122 => (8, scan_codeblock_rbrace_tag_action_0)
-     _ => (-1, [])
-   }
- }
+  match input {
+    48..=57 => (8, scan_codeblock_rbrace_tag_action_0)
+    65..=90 => (8, scan_codeblock_rbrace_tag_action_0)
+    95 => (8, scan_codeblock_rbrace_tag_action_0)
+    97..=122 => (8, scan_codeblock_rbrace_tag_action_0)
+    _ => (-1, [])
+  }
+}
 fn scan_codeblock_rbrace_state_9(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     48..=57 => (8, scan_codeblock_rbrace_tag_action_0)
-     65..=90 => (8, scan_codeblock_rbrace_tag_action_0)
-     95 => (8, scan_codeblock_rbrace_tag_action_0)
-     97..=99 => (8, scan_codeblock_rbrace_tag_action_0)
-     100 => (11, scan_codeblock_rbrace_tag_action_2)
-     101..=122 => (8, scan_codeblock_rbrace_tag_action_0)
-     _ => (-1, [])
-   }
- }
+  match input {
+    48..=57 => (8, scan_codeblock_rbrace_tag_action_0)
+    65..=90 => (8, scan_codeblock_rbrace_tag_action_0)
+    95 => (8, scan_codeblock_rbrace_tag_action_0)
+    97..=99 => (8, scan_codeblock_rbrace_tag_action_0)
+    100 => (11, scan_codeblock_rbrace_tag_action_2)
+    101..=122 => (8, scan_codeblock_rbrace_tag_action_0)
+    _ => (-1, [])
+  }
+}
 fn scan_codeblock_rbrace_state_10(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     48..=57 => (8, scan_codeblock_rbrace_tag_action_0)
-     65..=90 => (8, scan_codeblock_rbrace_tag_action_0)
-     95 => (8, scan_codeblock_rbrace_tag_action_0)
-     97 => (12, scan_codeblock_rbrace_tag_action_2)
-     98..=122 => (8, scan_codeblock_rbrace_tag_action_0)
-     _ => (-1, [])
-   }
- }
+  match input {
+    48..=57 => (8, scan_codeblock_rbrace_tag_action_0)
+    65..=90 => (8, scan_codeblock_rbrace_tag_action_0)
+    95 => (8, scan_codeblock_rbrace_tag_action_0)
+    97 => (12, scan_codeblock_rbrace_tag_action_2)
+    98..=122 => (8, scan_codeblock_rbrace_tag_action_0)
+    _ => (-1, [])
+  }
+}
 fn scan_codeblock_rbrace_state_11(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     48..=57 => (8, scan_codeblock_rbrace_tag_action_0)
-     65..=90 => (8, scan_codeblock_rbrace_tag_action_0)
-     95 => (8, scan_codeblock_rbrace_tag_action_0)
-     97..=111 => (8, scan_codeblock_rbrace_tag_action_0)
-     112 => (13, scan_codeblock_rbrace_tag_action_2)
-     113..=122 => (8, scan_codeblock_rbrace_tag_action_0)
-     _ => (-1, [])
-   }
- }
+  match input {
+    48..=57 => (8, scan_codeblock_rbrace_tag_action_0)
+    65..=90 => (8, scan_codeblock_rbrace_tag_action_0)
+    95 => (8, scan_codeblock_rbrace_tag_action_0)
+    97..=111 => (8, scan_codeblock_rbrace_tag_action_0)
+    112 => (13, scan_codeblock_rbrace_tag_action_2)
+    113..=122 => (8, scan_codeblock_rbrace_tag_action_0)
+    _ => (-1, [])
+  }
+}
 fn scan_codeblock_rbrace_state_12(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     48..=57 => (8, scan_codeblock_rbrace_tag_action_0)
-     65..=90 => (8, scan_codeblock_rbrace_tag_action_0)
-     95 => (8, scan_codeblock_rbrace_tag_action_0)
-     97..=113 => (8, scan_codeblock_rbrace_tag_action_0)
-     114 => (14, scan_codeblock_rbrace_tag_action_2)
-     115..=122 => (8, scan_codeblock_rbrace_tag_action_0)
-     _ => (-1, [])
-   }
- }
+  match input {
+    48..=57 => (8, scan_codeblock_rbrace_tag_action_0)
+    65..=90 => (8, scan_codeblock_rbrace_tag_action_0)
+    95 => (8, scan_codeblock_rbrace_tag_action_0)
+    97..=113 => (8, scan_codeblock_rbrace_tag_action_0)
+    114 => (14, scan_codeblock_rbrace_tag_action_2)
+    115..=122 => (8, scan_codeblock_rbrace_tag_action_0)
+    _ => (-1, [])
+  }
+}
 fn scan_codeblock_rbrace_state_13(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     48..=57 => (8, scan_codeblock_rbrace_tag_action_0)
-     65..=90 => (8, scan_codeblock_rbrace_tag_action_0)
-     95 => (8, scan_codeblock_rbrace_tag_action_0)
-     97..=110 => (8, scan_codeblock_rbrace_tag_action_0)
-     111 => (15, scan_codeblock_rbrace_tag_action_2)
-     112..=122 => (8, scan_codeblock_rbrace_tag_action_0)
-     _ => (-1, [])
-   }
- }
+  match input {
+    48..=57 => (8, scan_codeblock_rbrace_tag_action_0)
+    65..=90 => (8, scan_codeblock_rbrace_tag_action_0)
+    95 => (8, scan_codeblock_rbrace_tag_action_0)
+    97..=110 => (8, scan_codeblock_rbrace_tag_action_0)
+    111 => (15, scan_codeblock_rbrace_tag_action_2)
+    112..=122 => (8, scan_codeblock_rbrace_tag_action_0)
+    _ => (-1, [])
+  }
+}
 fn scan_codeblock_rbrace_state_14(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     48..=57 => (8, scan_codeblock_rbrace_tag_action_0)
-     65..=90 => (8, scan_codeblock_rbrace_tag_action_0)
-     95 => (8, scan_codeblock_rbrace_tag_action_0)
-     97..=115 => (8, scan_codeblock_rbrace_tag_action_0)
-     116 => (16, scan_codeblock_rbrace_tag_action_2)
-     117..=122 => (8, scan_codeblock_rbrace_tag_action_0)
-     _ => (-1, [])
-   }
- }
+  match input {
+    48..=57 => (8, scan_codeblock_rbrace_tag_action_0)
+    65..=90 => (8, scan_codeblock_rbrace_tag_action_0)
+    95 => (8, scan_codeblock_rbrace_tag_action_0)
+    97..=115 => (8, scan_codeblock_rbrace_tag_action_0)
+    116 => (16, scan_codeblock_rbrace_tag_action_2)
+    117..=122 => (8, scan_codeblock_rbrace_tag_action_0)
+    _ => (-1, [])
+  }
+}
 fn scan_codeblock_rbrace_state_15(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     48..=57 => (8, scan_codeblock_rbrace_tag_action_0)
-     65..=90 => (8, scan_codeblock_rbrace_tag_action_0)
-     95 => (8, scan_codeblock_rbrace_tag_action_0)
-     97..=114 => (8, scan_codeblock_rbrace_tag_action_0)
-     115 => (17, scan_codeblock_rbrace_tag_action_3)
-     116..=122 => (8, scan_codeblock_rbrace_tag_action_0)
-     _ => (-1, [])
-   }
- }
+  match input {
+    48..=57 => (8, scan_codeblock_rbrace_tag_action_0)
+    65..=90 => (8, scan_codeblock_rbrace_tag_action_0)
+    95 => (8, scan_codeblock_rbrace_tag_action_0)
+    97..=114 => (8, scan_codeblock_rbrace_tag_action_0)
+    115 => (17, scan_codeblock_rbrace_tag_action_3)
+    116..=122 => (8, scan_codeblock_rbrace_tag_action_0)
+    _ => (-1, [])
+  }
+}
 fn scan_codeblock_rbrace_state_16(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     48..=57 => (8, scan_codeblock_rbrace_tag_action_0)
-     65..=90 => (8, scan_codeblock_rbrace_tag_action_0)
-     95 => (8, scan_codeblock_rbrace_tag_action_0)
-     97..=111 => (8, scan_codeblock_rbrace_tag_action_0)
-     112 => (18, scan_codeblock_rbrace_tag_action_2)
-     113..=122 => (8, scan_codeblock_rbrace_tag_action_0)
-     _ => (-1, [])
-   }
- }
+  match input {
+    48..=57 => (8, scan_codeblock_rbrace_tag_action_0)
+    65..=90 => (8, scan_codeblock_rbrace_tag_action_0)
+    95 => (8, scan_codeblock_rbrace_tag_action_0)
+    97..=111 => (8, scan_codeblock_rbrace_tag_action_0)
+    112 => (18, scan_codeblock_rbrace_tag_action_2)
+    113..=122 => (8, scan_codeblock_rbrace_tag_action_0)
+    _ => (-1, [])
+  }
+}
 fn scan_codeblock_rbrace_state_17(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     40 => (19, scan_codeblock_rbrace_tag_action_4)
-     48..=57 => (8, scan_codeblock_rbrace_tag_action_0)
-     65..=90 => (8, scan_codeblock_rbrace_tag_action_0)
-     95 => (8, scan_codeblock_rbrace_tag_action_0)
-     97..=122 => (8, scan_codeblock_rbrace_tag_action_0)
-     _ => (-1, [])
-   }
- }
+  match input {
+    40 => (19, scan_codeblock_rbrace_tag_action_4)
+    48..=57 => (8, scan_codeblock_rbrace_tag_action_0)
+    65..=90 => (8, scan_codeblock_rbrace_tag_action_0)
+    95 => (8, scan_codeblock_rbrace_tag_action_0)
+    97..=122 => (8, scan_codeblock_rbrace_tag_action_0)
+    _ => (-1, [])
+  }
+}
 fn scan_codeblock_rbrace_state_18(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     48..=57 => (8, scan_codeblock_rbrace_tag_action_0)
-     65..=90 => (8, scan_codeblock_rbrace_tag_action_0)
-     95 => (8, scan_codeblock_rbrace_tag_action_0)
-     97..=110 => (8, scan_codeblock_rbrace_tag_action_0)
-     111 => (20, scan_codeblock_rbrace_tag_action_2)
-     112..=122 => (8, scan_codeblock_rbrace_tag_action_0)
-     _ => (-1, [])
-   }
- }
+  match input {
+    48..=57 => (8, scan_codeblock_rbrace_tag_action_0)
+    65..=90 => (8, scan_codeblock_rbrace_tag_action_0)
+    95 => (8, scan_codeblock_rbrace_tag_action_0)
+    97..=110 => (8, scan_codeblock_rbrace_tag_action_0)
+    111 => (20, scan_codeblock_rbrace_tag_action_2)
+    112..=122 => (8, scan_codeblock_rbrace_tag_action_0)
+    _ => (-1, [])
+  }
+}
 fn scan_codeblock_rbrace_state_19(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     9 => (22, scan_codeblock_rbrace_tag_action_4)
-     32 => (22, scan_codeblock_rbrace_tag_action_4)
-     65..=90 => (21, scan_codeblock_rbrace_tag_action_5)
-     95 => (21, scan_codeblock_rbrace_tag_action_5)
-     97..=122 => (21, scan_codeblock_rbrace_tag_action_5)
-     _ => (-1, [])
-   }
- }
+  match input {
+    9 => (22, scan_codeblock_rbrace_tag_action_4)
+    32 => (22, scan_codeblock_rbrace_tag_action_4)
+    65..=90 => (21, scan_codeblock_rbrace_tag_action_5)
+    95 => (21, scan_codeblock_rbrace_tag_action_5)
+    97..=122 => (21, scan_codeblock_rbrace_tag_action_5)
+    _ => (-1, [])
+  }
+}
 fn scan_codeblock_rbrace_state_20(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     48..=57 => (8, scan_codeblock_rbrace_tag_action_0)
-     65..=90 => (8, scan_codeblock_rbrace_tag_action_0)
-     95 => (8, scan_codeblock_rbrace_tag_action_0)
-     97..=114 => (8, scan_codeblock_rbrace_tag_action_0)
-     115 => (23, scan_codeblock_rbrace_tag_action_3)
-     116..=122 => (8, scan_codeblock_rbrace_tag_action_0)
-     _ => (-1, [])
-   }
- }
+  match input {
+    48..=57 => (8, scan_codeblock_rbrace_tag_action_0)
+    65..=90 => (8, scan_codeblock_rbrace_tag_action_0)
+    95 => (8, scan_codeblock_rbrace_tag_action_0)
+    97..=114 => (8, scan_codeblock_rbrace_tag_action_0)
+    115 => (23, scan_codeblock_rbrace_tag_action_3)
+    116..=122 => (8, scan_codeblock_rbrace_tag_action_0)
+    _ => (-1, [])
+  }
+}
 fn scan_codeblock_rbrace_state_21(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     9 => (25, scan_codeblock_rbrace_tag_action_6)
-     32 => (25, scan_codeblock_rbrace_tag_action_6)
-     41 => (26, scan_codeblock_rbrace_tag_action_7)
-     48..=57 => (24, scan_codeblock_rbrace_tag_action_5)
-     65..=90 => (24, scan_codeblock_rbrace_tag_action_5)
-     95 => (24, scan_codeblock_rbrace_tag_action_5)
-     97..=122 => (24, scan_codeblock_rbrace_tag_action_5)
-     _ => (-1, [])
-   }
- }
+  match input {
+    9 => (25, scan_codeblock_rbrace_tag_action_6)
+    32 => (25, scan_codeblock_rbrace_tag_action_6)
+    41 => (26, scan_codeblock_rbrace_tag_action_7)
+    48..=57 => (24, scan_codeblock_rbrace_tag_action_5)
+    65..=90 => (24, scan_codeblock_rbrace_tag_action_5)
+    95 => (24, scan_codeblock_rbrace_tag_action_5)
+    97..=122 => (24, scan_codeblock_rbrace_tag_action_5)
+    _ => (-1, [])
+  }
+}
 fn scan_codeblock_rbrace_state_22(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     9 => (22, scan_codeblock_rbrace_tag_action_4)
-     32 => (22, scan_codeblock_rbrace_tag_action_4)
-     65..=90 => (21, scan_codeblock_rbrace_tag_action_5)
-     95 => (21, scan_codeblock_rbrace_tag_action_5)
-     97..=122 => (21, scan_codeblock_rbrace_tag_action_5)
-     _ => (-1, [])
-   }
- }
+  match input {
+    9 => (22, scan_codeblock_rbrace_tag_action_4)
+    32 => (22, scan_codeblock_rbrace_tag_action_4)
+    65..=90 => (21, scan_codeblock_rbrace_tag_action_5)
+    95 => (21, scan_codeblock_rbrace_tag_action_5)
+    97..=122 => (21, scan_codeblock_rbrace_tag_action_5)
+    _ => (-1, [])
+  }
+}
 fn scan_codeblock_rbrace_state_23(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     40 => (19, scan_codeblock_rbrace_tag_action_4)
-     48..=57 => (8, scan_codeblock_rbrace_tag_action_0)
-     65..=90 => (8, scan_codeblock_rbrace_tag_action_0)
-     95 => (8, scan_codeblock_rbrace_tag_action_0)
-     97..=122 => (8, scan_codeblock_rbrace_tag_action_0)
-     _ => (-1, [])
-   }
- }
+  match input {
+    40 => (19, scan_codeblock_rbrace_tag_action_4)
+    48..=57 => (8, scan_codeblock_rbrace_tag_action_0)
+    65..=90 => (8, scan_codeblock_rbrace_tag_action_0)
+    95 => (8, scan_codeblock_rbrace_tag_action_0)
+    97..=122 => (8, scan_codeblock_rbrace_tag_action_0)
+    _ => (-1, [])
+  }
+}
 fn scan_codeblock_rbrace_state_24(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     9 => (25, scan_codeblock_rbrace_tag_action_6)
-     32 => (25, scan_codeblock_rbrace_tag_action_6)
-     41 => (26, scan_codeblock_rbrace_tag_action_7)
-     48..=57 => (24, scan_codeblock_rbrace_tag_action_5)
-     65..=90 => (24, scan_codeblock_rbrace_tag_action_5)
-     95 => (24, scan_codeblock_rbrace_tag_action_5)
-     97..=122 => (24, scan_codeblock_rbrace_tag_action_5)
-     _ => (-1, [])
-   }
- }
+  match input {
+    9 => (25, scan_codeblock_rbrace_tag_action_6)
+    32 => (25, scan_codeblock_rbrace_tag_action_6)
+    41 => (26, scan_codeblock_rbrace_tag_action_7)
+    48..=57 => (24, scan_codeblock_rbrace_tag_action_5)
+    65..=90 => (24, scan_codeblock_rbrace_tag_action_5)
+    95 => (24, scan_codeblock_rbrace_tag_action_5)
+    97..=122 => (24, scan_codeblock_rbrace_tag_action_5)
+    _ => (-1, [])
+  }
+}
 fn scan_codeblock_rbrace_state_25(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     9 => (25, scan_codeblock_rbrace_tag_action_6)
-     32 => (25, scan_codeblock_rbrace_tag_action_6)
-     41 => (26, scan_codeblock_rbrace_tag_action_7)
-     _ => (-1, [])
-   }
- }
+  match input {
+    9 => (25, scan_codeblock_rbrace_tag_action_6)
+    32 => (25, scan_codeblock_rbrace_tag_action_6)
+    41 => (26, scan_codeblock_rbrace_tag_action_7)
+    _ => (-1, [])
+  }
+}
 fn scan_codeblock_rbrace_state_26(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     _ => (-1, [])
-   }
- }
+  match input {
+    _ => (-1, [])
+  }
+}
 
 let __mbtlex_engine_scan_codeblock_rbrace: LexEngine = { graph: [scan_codeblock_rbrace_state_0, scan_codeblock_rbrace_state_1, scan_codeblock_rbrace_state_2, scan_codeblock_rbrace_state_3, scan_codeblock_rbrace_state_4, scan_codeblock_rbrace_state_5, scan_codeblock_rbrace_state_6, scan_codeblock_rbrace_state_7, scan_codeblock_rbrace_state_8, scan_codeblock_rbrace_state_9, scan_codeblock_rbrace_state_10, scan_codeblock_rbrace_state_11, scan_codeblock_rbrace_state_12, scan_codeblock_rbrace_state_13, scan_codeblock_rbrace_state_14, scan_codeblock_rbrace_state_15, scan_codeblock_rbrace_state_16, scan_codeblock_rbrace_state_17, scan_codeblock_rbrace_state_18, scan_codeblock_rbrace_state_19, scan_codeblock_rbrace_state_20, scan_codeblock_rbrace_state_21, scan_codeblock_rbrace_state_22, scan_codeblock_rbrace_state_23, scan_codeblock_rbrace_state_24, scan_codeblock_rbrace_state_25, scan_codeblock_rbrace_state_26, ], end_nodes: [Some((5, [])), Some((4, [])), Some((4, [])), Some((1, [])), Some((0, [])), Some((3, [])), Some((3, [])), Some((3, [])), Some((3, [])), Some((3, [])), Some((3, [])), Some((3, [])), Some((3, [])), Some((3, [])), Some((3, [])), Some((3, [])), Some((3, [])), Some((3, [])), Some((3, [])), None, Some((3, [])), None, None, Some((3, [])), None, None, Some((2, [((0, 0), (1, 0)), ((2, 0), (3, 0)), ((4, 0), (5, 0))]))], start_tags: [0], code_blocks_n: 6 }
 fn scan_codeblock_rbrace( subst :  Array[SubstItem], lexbuf : Lexbuf ) ->  Unit  {
- match __mbtlex_engine_scan_codeblock_rbrace.run(lexbuf) {
- (0, __mbtlex_captures) => {
- 
-       scan_codeblock_rbrace(subst, lexbuf)
-       scan_codeblock_rbrace(subst, lexbuf)
-     
- }
- (1, __mbtlex_captures) => {
-  () 
- }
- (2, __mbtlex_captures) => {
- let (_start_pos_of_t, _end_pos_of_t) = __mbtlex_captures[0]
- let t: String = lexbuf.substring(_start_pos_of_t, _end_pos_of_t)
- ignore(t)
- let (_start_pos_of_t1, _end_pos_of_t1) = __mbtlex_captures[1]
- let t1: String = lexbuf.substring(_start_pos_of_t1, _end_pos_of_t1)
- 
- let (_start_pos_of_t2, _end_pos_of_t2) = __mbtlex_captures[2]
- let t2: String = lexbuf.substring(_start_pos_of_t2, _end_pos_of_t2)
- 
- 
-       subst.push({ 
-         start: _start_pos_of_t, 
-         end: _end_pos_of_t, 
-         desc: match t1 {
-           "startpos" => StartPosOf(t2)
-           "endpos" => EndPosOf(t2)
-           _ => panic()
-         }
-       })
-       scan_codeblock_rbrace(subst, lexbuf)
-     
- }
- (3, __mbtlex_captures) => {
- 
-       scan_codeblock_rbrace(subst, lexbuf)
-     
- }
- (4, __mbtlex_captures) => {
-  scan_codeblock_rbrace(subst, lexbuf) 
- }
- (5, __mbtlex_captures) => {
-  () 
- }
- _ => abort("lex: fail to match")
- }
- }
+  match __mbtlex_engine_scan_codeblock_rbrace.run(lexbuf) {
+    (0, __mbtlex_captures) => {
+
+      scan_codeblock_rbrace(subst, lexbuf)
+      scan_codeblock_rbrace(subst, lexbuf)
+    
+    }
+    (1, __mbtlex_captures) => {
+ () 
+    }
+    (2, __mbtlex_captures) => {
+  let (_start_pos_of_t, _end_pos_of_t) = __mbtlex_captures[0]
+  let t: String = lexbuf.substring(_start_pos_of_t, _end_pos_of_t)
+  ignore(t)
+  let (_start_pos_of_t1, _end_pos_of_t1) = __mbtlex_captures[1]
+  let t1: String = lexbuf.substring(_start_pos_of_t1, _end_pos_of_t1)
+  
+  let (_start_pos_of_t2, _end_pos_of_t2) = __mbtlex_captures[2]
+  let t2: String = lexbuf.substring(_start_pos_of_t2, _end_pos_of_t2)
+  
+
+      subst.push({ 
+        start: _start_pos_of_t, 
+        end: _end_pos_of_t, 
+        desc: match t1 {
+          "startpos" => StartPosOf(t2)
+          "endpos" => EndPosOf(t2)
+          _ => panic()
+        }
+      })
+      scan_codeblock_rbrace(subst, lexbuf)
+    
+    }
+    (3, __mbtlex_captures) => {
+
+      scan_codeblock_rbrace(subst, lexbuf)
+    
+    }
+    (4, __mbtlex_captures) => {
+ scan_codeblock_rbrace(subst, lexbuf) 
+    }
+    (5, __mbtlex_captures) => {
+ () 
+    }
+    _ => abort("lex: fail to match")
+  }
+}
 
 
 pub fn parse_codeblock(str : String) -> Array[SubstItem] {
-   let lexbuf = Lexbuf::from_string(str)
-   let subst = []
-   scan_codeblock_rbrace(subst, lexbuf)
-   subst
- }
+  let lexbuf = Lexbuf::from_string(str)
+  let subst = []
+  scan_codeblock_rbrace(subst, lexbuf)
+  subst
+}

--- a/src/tests/eof_test/eof.mbt
+++ b/src/tests/eof_test/eof.mbt
@@ -1,31 +1,30 @@
-
 ///|
 struct Lexbuf {
-   content : String
-   mut pos : Int
- }
+  content : String
+  mut pos : Int
+}
 
 ///|
 pub fn Lexbuf::from_string(content : String) -> Lexbuf {
-   { content, pos: 0 }
- }
+  { content, pos: 0 }
+}
 
 // NOTE: MoonBit do have unboxed Option[Char] optimization
 ///|
 fn next(self : Lexbuf) -> Char? {
-   if self.pos < self.content.length() {
-     let ch = self.content[self.pos]
-     self.pos += 1
-     Some(ch)
-   } else {
-     None
-   }
- }
+  if self.pos < self.content.length() {
+    let ch = self.content[self.pos]
+    self.pos += 1
+    Some(ch)
+  } else {
+    None
+  }
+}
 
 ///|
 fn substring(self : Lexbuf, start : Int, end : Int) -> String {
-   self.content.substring(start~, end~)
- }
+  self.content.substring(start~, end~)
+}
 
 ///|
 typealias LexTagAction = Array[Array[Int]]
@@ -38,124 +37,124 @@ typealias LexInput = Int
 
 ///|
 pub(all) struct LexEngine {
-   graph : Array[(LexState) -> (LexState, LexTagAction)]
-   end_nodes : Array[(Int, Array[((Int, Int), (Int, Int))])?]
-   start_tags : Array[Int]
-   code_blocks_n : Int
- }
+  graph : Array[(LexState) -> (LexState, LexTagAction)]
+  end_nodes : Array[(Int, Array[((Int, Int), (Int, Int))])?]
+  start_tags : Array[Int]
+  code_blocks_n : Int
+}
 
 ///|
 pub fn run(self : LexEngine, lexbuf : Lexbuf) -> (Int, Array[(Int, Int)]) {
-   let mut state = 0
-   let mut tagState : Array[Array[Int]] = []
-   let backtrace = Array::make(self.code_blocks_n, None)
-   for tag in self.start_tags {
-     while tagState.length() <= tag {
-       tagState.push([])
-     }
-     tagState[tag].push(lexbuf.pos)
-   }
-   while state != -1 {
-     match self.end_nodes[state] {
-       Some(t) => backtrace[t.0] = Some((lexbuf.pos, state, tagState))
-       _ => ()
-     }
-     let b = match lexbuf.next() {
-       Some(b) => b.to_int()
-       None => -1
-     }
-     let next = self.graph[state](b)
-     state = next.0
-     let new_tagState : Array[Array[Int]] = []
-     for i = 0; i < next.1.length(); i = i + 1 {
-       new_tagState.push([])
-       for j = 0; j < next.1[i].length(); j = j + 1 {
-         let t = next.1[i][j]
-         if t == -1 {
-           new_tagState[i].push(lexbuf.pos)
-         } else {
-           new_tagState[i].push(tagState[i][t])
-         }
-       }
-     }
-     tagState = new_tagState
-   }
-   for index, b in backtrace {
-     match b {
-       Some((p, state, tagState)) => {
-         lexbuf.pos = p
-         let captures = self.end_nodes[state].unwrap().1.map(fn {
-           ((b_t, b_r), (e_t, e_r)) => (tagState[b_t][b_r], tagState[e_t][e_r])
-         })
-         break (index, captures)
-       }
-       None => ()
-     }
-   } else {
-     (self.code_blocks_n, [])
-   }
- }
+  let mut state = 0
+  let mut tagState : Array[Array[Int]] = []
+  let backtrace = Array::make(self.code_blocks_n, None)
+  for tag in self.start_tags {
+    while tagState.length() <= tag {
+      tagState.push([])
+    }
+    tagState[tag].push(lexbuf.pos)
+  }
+  while state != -1 {
+    match self.end_nodes[state] {
+      Some(t) => backtrace[t.0] = Some((lexbuf.pos, state, tagState))
+      _ => ()
+    }
+    let b = match lexbuf.next() {
+      Some(b) => b.to_int()
+      None => -1
+    }
+    let next = self.graph[state](b)
+    state = next.0
+    let new_tagState : Array[Array[Int]] = []
+    for i = 0; i < next.1.length(); i = i + 1 {
+      new_tagState.push([])
+      for j = 0; j < next.1[i].length(); j = j + 1 {
+        let t = next.1[i][j]
+        if t == -1 {
+          new_tagState[i].push(lexbuf.pos)
+        } else {
+          new_tagState[i].push(tagState[i][t])
+        }
+      }
+    }
+    tagState = new_tagState
+  }
+  for index, b in backtrace {
+    match b {
+      Some((p, state, tagState)) => {
+        lexbuf.pos = p
+        let captures = self.end_nodes[state].unwrap().1.map(fn {
+          ((b_t, b_r), (e_t, e_r)) => (tagState[b_t][b_r], tagState[e_t][e_r])
+        })
+        break (index, captures)
+      }
+      None => ()
+    }
+  } else {
+    (self.code_blocks_n, [])
+  }
+}
 
 
 
 priv enum Token {
-   PERCENT
-   PERCENT_EOF
-   NON_PERCENT
-   EOF
- } derive(ToJson)
+  PERCENT
+  PERCENT_EOF
+  NON_PERCENT
+  EOF
+} derive(ToJson)
 
 
 
 let token_tag_action_0 : Array[Array[Int]] = []
 
 fn token_state_0(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     -1 => (1, token_tag_action_0)
-     0..=36 => (2, token_tag_action_0)
-     37 => (3, token_tag_action_0)
-     38..=1114111 => (2, token_tag_action_0)
-     _ => (-1, [])
-   }
- }
+  match input {
+    -1 => (1, token_tag_action_0)
+    0..=36 => (2, token_tag_action_0)
+    37 => (3, token_tag_action_0)
+    38..=1114111 => (2, token_tag_action_0)
+    _ => (-1, [])
+  }
+}
 fn token_state_1(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     _ => (-1, [])
-   }
- }
+  match input {
+    _ => (-1, [])
+  }
+}
 fn token_state_2(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     _ => (-1, [])
-   }
- }
+  match input {
+    _ => (-1, [])
+  }
+}
 fn token_state_3(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     -1 => (4, token_tag_action_0)
-     _ => (-1, [])
-   }
- }
+  match input {
+    -1 => (4, token_tag_action_0)
+    _ => (-1, [])
+  }
+}
 fn token_state_4(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     _ => (-1, [])
-   }
- }
+  match input {
+    _ => (-1, [])
+  }
+}
 
 let __mbtlex_engine_token: LexEngine = { graph: [token_state_0, token_state_1, token_state_2, token_state_3, token_state_4, ], end_nodes: [None, Some((3, [])), Some((2, [])), Some((1, [])), Some((0, []))], start_tags: [], code_blocks_n: 4 }
 fn token( lexbuf : Lexbuf ) ->  Token  {
- match __mbtlex_engine_token.run(lexbuf) {
- (0, __mbtlex_captures) => {
-  PERCENT_EOF 
- }
- (1, __mbtlex_captures) => {
-  PERCENT 
- }
- (2, __mbtlex_captures) => {
-  NON_PERCENT 
- }
- (3, __mbtlex_captures) => {
-  EOF 
- }
- _ => abort("lex: fail to match")
- }
- }
+  match __mbtlex_engine_token.run(lexbuf) {
+    (0, __mbtlex_captures) => {
+ PERCENT_EOF 
+    }
+    (1, __mbtlex_captures) => {
+ PERCENT 
+    }
+    (2, __mbtlex_captures) => {
+ NON_PERCENT 
+    }
+    (3, __mbtlex_captures) => {
+ EOF 
+    }
+    _ => abort("lex: fail to match")
+  }
+}
 

--- a/src/tests/fortytwolexer/fortytwolexer.mbt
+++ b/src/tests/fortytwolexer/fortytwolexer.mbt
@@ -1,31 +1,30 @@
-
 ///|
 struct Lexbuf {
-   content : String
-   mut pos : Int
- }
+  content : String
+  mut pos : Int
+}
 
 ///|
 pub fn Lexbuf::from_string(content : String) -> Lexbuf {
-   { content, pos: 0 }
- }
+  { content, pos: 0 }
+}
 
 // NOTE: MoonBit do have unboxed Option[Char] optimization
 ///|
 fn next(self : Lexbuf) -> Char? {
-   if self.pos < self.content.length() {
-     let ch = self.content[self.pos]
-     self.pos += 1
-     Some(ch)
-   } else {
-     None
-   }
- }
+  if self.pos < self.content.length() {
+    let ch = self.content[self.pos]
+    self.pos += 1
+    Some(ch)
+  } else {
+    None
+  }
+}
 
 ///|
 fn substring(self : Lexbuf, start : Int, end : Int) -> String {
-   self.content.substring(start~, end~)
- }
+  self.content.substring(start~, end~)
+}
 
 ///|
 typealias LexTagAction = Array[Array[Int]]
@@ -38,63 +37,63 @@ typealias LexInput = Int
 
 ///|
 pub(all) struct LexEngine {
-   graph : Array[(LexState) -> (LexState, LexTagAction)]
-   end_nodes : Array[(Int, Array[((Int, Int), (Int, Int))])?]
-   start_tags : Array[Int]
-   code_blocks_n : Int
- }
+  graph : Array[(LexState) -> (LexState, LexTagAction)]
+  end_nodes : Array[(Int, Array[((Int, Int), (Int, Int))])?]
+  start_tags : Array[Int]
+  code_blocks_n : Int
+}
 
 ///|
 pub fn run(self : LexEngine, lexbuf : Lexbuf) -> (Int, Array[(Int, Int)]) {
-   let mut state = 0
-   let mut tagState : Array[Array[Int]] = []
-   let backtrace = Array::make(self.code_blocks_n, None)
-   for tag in self.start_tags {
-     while tagState.length() <= tag {
-       tagState.push([])
-     }
-     tagState[tag].push(lexbuf.pos)
-   }
-   while state != -1 {
-     match self.end_nodes[state] {
-       Some(t) => backtrace[t.0] = Some((lexbuf.pos, state, tagState))
-       _ => ()
-     }
-     let b = match lexbuf.next() {
-       Some(b) => b.to_int()
-       None => -1
-     }
-     let next = self.graph[state](b)
-     state = next.0
-     let new_tagState : Array[Array[Int]] = []
-     for i = 0; i < next.1.length(); i = i + 1 {
-       new_tagState.push([])
-       for j = 0; j < next.1[i].length(); j = j + 1 {
-         let t = next.1[i][j]
-         if t == -1 {
-           new_tagState[i].push(lexbuf.pos)
-         } else {
-           new_tagState[i].push(tagState[i][t])
-         }
-       }
-     }
-     tagState = new_tagState
-   }
-   for index, b in backtrace {
-     match b {
-       Some((p, state, tagState)) => {
-         lexbuf.pos = p
-         let captures = self.end_nodes[state].unwrap().1.map(fn {
-           ((b_t, b_r), (e_t, e_r)) => (tagState[b_t][b_r], tagState[e_t][e_r])
-         })
-         break (index, captures)
-       }
-       None => ()
-     }
-   } else {
-     (self.code_blocks_n, [])
-   }
- }
+  let mut state = 0
+  let mut tagState : Array[Array[Int]] = []
+  let backtrace = Array::make(self.code_blocks_n, None)
+  for tag in self.start_tags {
+    while tagState.length() <= tag {
+      tagState.push([])
+    }
+    tagState[tag].push(lexbuf.pos)
+  }
+  while state != -1 {
+    match self.end_nodes[state] {
+      Some(t) => backtrace[t.0] = Some((lexbuf.pos, state, tagState))
+      _ => ()
+    }
+    let b = match lexbuf.next() {
+      Some(b) => b.to_int()
+      None => -1
+    }
+    let next = self.graph[state](b)
+    state = next.0
+    let new_tagState : Array[Array[Int]] = []
+    for i = 0; i < next.1.length(); i = i + 1 {
+      new_tagState.push([])
+      for j = 0; j < next.1[i].length(); j = j + 1 {
+        let t = next.1[i][j]
+        if t == -1 {
+          new_tagState[i].push(lexbuf.pos)
+        } else {
+          new_tagState[i].push(tagState[i][t])
+        }
+      }
+    }
+    tagState = new_tagState
+  }
+  for index, b in backtrace {
+    match b {
+      Some((p, state, tagState)) => {
+        lexbuf.pos = p
+        let captures = self.end_nodes[state].unwrap().1.map(fn {
+          ((b_t, b_r), (e_t, e_r)) => (tagState[b_t][b_r], tagState[e_t][e_r])
+        })
+        break (index, captures)
+      }
+      None => ()
+    }
+  } else {
+    (self.code_blocks_n, [])
+  }
+}
 
 
 
@@ -108,62 +107,62 @@ let scan_newline_tag_action_0 : Array[Array[Int]] = [scan_newline_tag_action_row
 let scan_newline_tag_action_1 : Array[Array[Int]] = [scan_newline_tag_action_row_1, scan_newline_tag_action_row_2]
 
 fn scan_newline_state_0(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     0..=9 => (3, scan_newline_tag_action_0)
-     10 => (1, scan_newline_tag_action_1)
-     11..=12 => (3, scan_newline_tag_action_0)
-     13 => (2, scan_newline_tag_action_1)
-     14..=1114111 => (3, scan_newline_tag_action_0)
-     _ => (-1, [])
-   }
- }
+  match input {
+    0..=9 => (3, scan_newline_tag_action_0)
+    10 => (1, scan_newline_tag_action_1)
+    11..=12 => (3, scan_newline_tag_action_0)
+    13 => (2, scan_newline_tag_action_1)
+    14..=1114111 => (3, scan_newline_tag_action_0)
+    _ => (-1, [])
+  }
+}
 fn scan_newline_state_1(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     _ => (-1, [])
-   }
- }
+  match input {
+    _ => (-1, [])
+  }
+}
 fn scan_newline_state_2(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     10 => (5, scan_newline_tag_action_1)
-     13 => (4, scan_newline_tag_action_1)
-     _ => (-1, [])
-   }
- }
+  match input {
+    10 => (5, scan_newline_tag_action_1)
+    13 => (4, scan_newline_tag_action_1)
+    _ => (-1, [])
+  }
+}
 fn scan_newline_state_3(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     _ => (-1, [])
-   }
- }
+  match input {
+    _ => (-1, [])
+  }
+}
 fn scan_newline_state_4(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     _ => (-1, [])
-   }
- }
+  match input {
+    _ => (-1, [])
+  }
+}
 fn scan_newline_state_5(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     _ => (-1, [])
-   }
- }
+  match input {
+    _ => (-1, [])
+  }
+}
 
 let __mbtlex_engine_scan_newline: LexEngine = { graph: [scan_newline_state_0, scan_newline_state_1, scan_newline_state_2, scan_newline_state_3, scan_newline_state_4, scan_newline_state_5, ], end_nodes: [Some((2, [])), Some((0, [((0, 0), (1, 0))])), Some((0, [((0, 0), (1, 0))])), Some((1, [])), Some((0, [((0, 0), (1, 0))])), Some((0, [((0, 0), (1, 0))]))], start_tags: [0], code_blocks_n: 3 }
 fn scan_newline( lexbuf : Lexbuf ) ->  Int  {
- match __mbtlex_engine_scan_newline.run(lexbuf) {
- (0, __mbtlex_captures) => {
- let (_start_pos_of_t, _end_pos_of_t) = __mbtlex_captures[0]
- let t: String = lexbuf.substring(_start_pos_of_t, _end_pos_of_t)
- ignore(t)
- 
-       _start_pos_of_t
-     
- }
- (1, __mbtlex_captures) => {
-  scan_newline(lexbuf) 
- }
- (2, __mbtlex_captures) => {
-  -1 
- }
- _ => abort("lex: fail to match")
- }
- }
+  match __mbtlex_engine_scan_newline.run(lexbuf) {
+    (0, __mbtlex_captures) => {
+  let (_start_pos_of_t, _end_pos_of_t) = __mbtlex_captures[0]
+  let t: String = lexbuf.substring(_start_pos_of_t, _end_pos_of_t)
+  ignore(t)
+
+      _start_pos_of_t
+    
+    }
+    (1, __mbtlex_captures) => {
+ scan_newline(lexbuf) 
+    }
+    (2, __mbtlex_captures) => {
+ -1 
+    }
+    _ => abort("lex: fail to match")
+  }
+}
 
 

--- a/src/tests/issue12/issue12.mbt
+++ b/src/tests/issue12/issue12.mbt
@@ -1,31 +1,30 @@
-
 ///|
 struct Lexbuf {
-   content : String
-   mut pos : Int
- }
+  content : String
+  mut pos : Int
+}
 
 ///|
 pub fn Lexbuf::from_string(content : String) -> Lexbuf {
-   { content, pos: 0 }
- }
+  { content, pos: 0 }
+}
 
 // NOTE: MoonBit do have unboxed Option[Char] optimization
 ///|
 fn next(self : Lexbuf) -> Char? {
-   if self.pos < self.content.length() {
-     let ch = self.content[self.pos]
-     self.pos += 1
-     Some(ch)
-   } else {
-     None
-   }
- }
+  if self.pos < self.content.length() {
+    let ch = self.content[self.pos]
+    self.pos += 1
+    Some(ch)
+  } else {
+    None
+  }
+}
 
 ///|
 fn substring(self : Lexbuf, start : Int, end : Int) -> String {
-   self.content.substring(start~, end~)
- }
+  self.content.substring(start~, end~)
+}
 
 ///|
 typealias LexTagAction = Array[Array[Int]]
@@ -38,63 +37,63 @@ typealias LexInput = Int
 
 ///|
 pub(all) struct LexEngine {
-   graph : Array[(LexState) -> (LexState, LexTagAction)]
-   end_nodes : Array[(Int, Array[((Int, Int), (Int, Int))])?]
-   start_tags : Array[Int]
-   code_blocks_n : Int
- }
+  graph : Array[(LexState) -> (LexState, LexTagAction)]
+  end_nodes : Array[(Int, Array[((Int, Int), (Int, Int))])?]
+  start_tags : Array[Int]
+  code_blocks_n : Int
+}
 
 ///|
 pub fn run(self : LexEngine, lexbuf : Lexbuf) -> (Int, Array[(Int, Int)]) {
-   let mut state = 0
-   let mut tagState : Array[Array[Int]] = []
-   let backtrace = Array::make(self.code_blocks_n, None)
-   for tag in self.start_tags {
-     while tagState.length() <= tag {
-       tagState.push([])
-     }
-     tagState[tag].push(lexbuf.pos)
-   }
-   while state != -1 {
-     match self.end_nodes[state] {
-       Some(t) => backtrace[t.0] = Some((lexbuf.pos, state, tagState))
-       _ => ()
-     }
-     let b = match lexbuf.next() {
-       Some(b) => b.to_int()
-       None => -1
-     }
-     let next = self.graph[state](b)
-     state = next.0
-     let new_tagState : Array[Array[Int]] = []
-     for i = 0; i < next.1.length(); i = i + 1 {
-       new_tagState.push([])
-       for j = 0; j < next.1[i].length(); j = j + 1 {
-         let t = next.1[i][j]
-         if t == -1 {
-           new_tagState[i].push(lexbuf.pos)
-         } else {
-           new_tagState[i].push(tagState[i][t])
-         }
-       }
-     }
-     tagState = new_tagState
-   }
-   for index, b in backtrace {
-     match b {
-       Some((p, state, tagState)) => {
-         lexbuf.pos = p
-         let captures = self.end_nodes[state].unwrap().1.map(fn {
-           ((b_t, b_r), (e_t, e_r)) => (tagState[b_t][b_r], tagState[e_t][e_r])
-         })
-         break (index, captures)
-       }
-       None => ()
-     }
-   } else {
-     (self.code_blocks_n, [])
-   }
- }
+  let mut state = 0
+  let mut tagState : Array[Array[Int]] = []
+  let backtrace = Array::make(self.code_blocks_n, None)
+  for tag in self.start_tags {
+    while tagState.length() <= tag {
+      tagState.push([])
+    }
+    tagState[tag].push(lexbuf.pos)
+  }
+  while state != -1 {
+    match self.end_nodes[state] {
+      Some(t) => backtrace[t.0] = Some((lexbuf.pos, state, tagState))
+      _ => ()
+    }
+    let b = match lexbuf.next() {
+      Some(b) => b.to_int()
+      None => -1
+    }
+    let next = self.graph[state](b)
+    state = next.0
+    let new_tagState : Array[Array[Int]] = []
+    for i = 0; i < next.1.length(); i = i + 1 {
+      new_tagState.push([])
+      for j = 0; j < next.1[i].length(); j = j + 1 {
+        let t = next.1[i][j]
+        if t == -1 {
+          new_tagState[i].push(lexbuf.pos)
+        } else {
+          new_tagState[i].push(tagState[i][t])
+        }
+      }
+    }
+    tagState = new_tagState
+  }
+  for index, b in backtrace {
+    match b {
+      Some((p, state, tagState)) => {
+        lexbuf.pos = p
+        let captures = self.end_nodes[state].unwrap().1.map(fn {
+          ((b_t, b_r), (e_t, e_r)) => (tagState[b_t][b_r], tagState[e_t][e_r])
+        })
+        break (index, captures)
+      }
+      None => ()
+    }
+  } else {
+    (self.code_blocks_n, [])
+  }
+}
 
 
 
@@ -107,45 +106,45 @@ let test_func_tag_action_1 : Array[Array[Int]] = [test_func_tag_action_row_0, te
 let test_func_tag_action_0 : Array[Array[Int]] = [test_func_tag_action_row_0, test_func_tag_action_row_2]
 
 fn test_func_state_0(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     97 => (1, test_func_tag_action_0)
-     _ => (-1, [])
-   }
- }
+  match input {
+    97 => (1, test_func_tag_action_0)
+    _ => (-1, [])
+  }
+}
 fn test_func_state_1(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     97..=98 => (2, test_func_tag_action_1)
-     _ => (-1, [])
-   }
- }
+  match input {
+    97..=98 => (2, test_func_tag_action_1)
+    _ => (-1, [])
+  }
+}
 fn test_func_state_2(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     97 => (3, test_func_tag_action_0)
-     98 => (2, test_func_tag_action_1)
-     _ => (-1, [])
-   }
- }
+  match input {
+    97 => (3, test_func_tag_action_0)
+    98 => (2, test_func_tag_action_1)
+    _ => (-1, [])
+  }
+}
 fn test_func_state_3(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     97 => (3, test_func_tag_action_0)
-     98 => (2, test_func_tag_action_1)
-     _ => (-1, [])
-   }
- }
+  match input {
+    97 => (3, test_func_tag_action_0)
+    98 => (2, test_func_tag_action_1)
+    _ => (-1, [])
+  }
+}
 
 let __mbtlex_engine_test_func: LexEngine = { graph: [test_func_state_0, test_func_state_1, test_func_state_2, test_func_state_3, ], end_nodes: [None, Some((0, [((0, 0), (1, 0))])), None, Some((0, [((0, 0), (1, 0))]))], start_tags: [0], code_blocks_n: 1 }
 fn test_func( lexbuf : Lexbuf ) ->  String  {
- match __mbtlex_engine_test_func.run(lexbuf) {
- (0, __mbtlex_captures) => {
- let (_start_pos_of_t2, _end_pos_of_t2) = __mbtlex_captures[0]
- let t2: String = lexbuf.substring(_start_pos_of_t2, _end_pos_of_t2)
- 
- 
-       t2
-     
- }
- _ => abort("lex: fail to match")
- }
- }
+  match __mbtlex_engine_test_func.run(lexbuf) {
+    (0, __mbtlex_captures) => {
+  let (_start_pos_of_t2, _end_pos_of_t2) = __mbtlex_captures[0]
+  let t2: String = lexbuf.substring(_start_pos_of_t2, _end_pos_of_t2)
+  
+
+      t2
+    
+    }
+    _ => abort("lex: fail to match")
+  }
+}
 
 

--- a/src/tests/jsonlexer/jsonlexer.mbt
+++ b/src/tests/jsonlexer/jsonlexer.mbt
@@ -1,31 +1,30 @@
-
 ///|
 struct Lexbuf {
-   content : String
-   mut pos : Int
- }
+  content : String
+  mut pos : Int
+}
 
 ///|
 pub fn Lexbuf::from_string(content : String) -> Lexbuf {
-   { content, pos: 0 }
- }
+  { content, pos: 0 }
+}
 
 // NOTE: MoonBit do have unboxed Option[Char] optimization
 ///|
 fn next(self : Lexbuf) -> Char? {
-   if self.pos < self.content.length() {
-     let ch = self.content[self.pos]
-     self.pos += 1
-     Some(ch)
-   } else {
-     None
-   }
- }
+  if self.pos < self.content.length() {
+    let ch = self.content[self.pos]
+    self.pos += 1
+    Some(ch)
+  } else {
+    None
+  }
+}
 
 ///|
 fn substring(self : Lexbuf, start : Int, end : Int) -> String {
-   self.content.substring(start~, end~)
- }
+  self.content.substring(start~, end~)
+}
 
 ///|
 typealias LexTagAction = Array[Array[Int]]
@@ -38,86 +37,86 @@ typealias LexInput = Int
 
 ///|
 pub(all) struct LexEngine {
-   graph : Array[(LexState) -> (LexState, LexTagAction)]
-   end_nodes : Array[(Int, Array[((Int, Int), (Int, Int))])?]
-   start_tags : Array[Int]
-   code_blocks_n : Int
- }
+  graph : Array[(LexState) -> (LexState, LexTagAction)]
+  end_nodes : Array[(Int, Array[((Int, Int), (Int, Int))])?]
+  start_tags : Array[Int]
+  code_blocks_n : Int
+}
 
 ///|
 pub fn run(self : LexEngine, lexbuf : Lexbuf) -> (Int, Array[(Int, Int)]) {
-   let mut state = 0
-   let mut tagState : Array[Array[Int]] = []
-   let backtrace = Array::make(self.code_blocks_n, None)
-   for tag in self.start_tags {
-     while tagState.length() <= tag {
-       tagState.push([])
-     }
-     tagState[tag].push(lexbuf.pos)
-   }
-   while state != -1 {
-     match self.end_nodes[state] {
-       Some(t) => backtrace[t.0] = Some((lexbuf.pos, state, tagState))
-       _ => ()
-     }
-     let b = match lexbuf.next() {
-       Some(b) => b.to_int()
-       None => -1
-     }
-     let next = self.graph[state](b)
-     state = next.0
-     let new_tagState : Array[Array[Int]] = []
-     for i = 0; i < next.1.length(); i = i + 1 {
-       new_tagState.push([])
-       for j = 0; j < next.1[i].length(); j = j + 1 {
-         let t = next.1[i][j]
-         if t == -1 {
-           new_tagState[i].push(lexbuf.pos)
-         } else {
-           new_tagState[i].push(tagState[i][t])
-         }
-       }
-     }
-     tagState = new_tagState
-   }
-   for index, b in backtrace {
-     match b {
-       Some((p, state, tagState)) => {
-         lexbuf.pos = p
-         let captures = self.end_nodes[state].unwrap().1.map(fn {
-           ((b_t, b_r), (e_t, e_r)) => (tagState[b_t][b_r], tagState[e_t][e_r])
-         })
-         break (index, captures)
-       }
-       None => ()
-     }
-   } else {
-     (self.code_blocks_n, [])
-   }
- }
+  let mut state = 0
+  let mut tagState : Array[Array[Int]] = []
+  let backtrace = Array::make(self.code_blocks_n, None)
+  for tag in self.start_tags {
+    while tagState.length() <= tag {
+      tagState.push([])
+    }
+    tagState[tag].push(lexbuf.pos)
+  }
+  while state != -1 {
+    match self.end_nodes[state] {
+      Some(t) => backtrace[t.0] = Some((lexbuf.pos, state, tagState))
+      _ => ()
+    }
+    let b = match lexbuf.next() {
+      Some(b) => b.to_int()
+      None => -1
+    }
+    let next = self.graph[state](b)
+    state = next.0
+    let new_tagState : Array[Array[Int]] = []
+    for i = 0; i < next.1.length(); i = i + 1 {
+      new_tagState.push([])
+      for j = 0; j < next.1[i].length(); j = j + 1 {
+        let t = next.1[i][j]
+        if t == -1 {
+          new_tagState[i].push(lexbuf.pos)
+        } else {
+          new_tagState[i].push(tagState[i][t])
+        }
+      }
+    }
+    tagState = new_tagState
+  }
+  for index, b in backtrace {
+    match b {
+      Some((p, state, tagState)) => {
+        lexbuf.pos = p
+        let captures = self.end_nodes[state].unwrap().1.map(fn {
+          ((b_t, b_r), (e_t, e_r)) => (tagState[b_t][b_r], tagState[e_t][e_r])
+        })
+        break (index, captures)
+      }
+      None => ()
+    }
+  } else {
+    (self.code_blocks_n, [])
+  }
+}
 
 
 
 priv enum Token {
-   WHITESPACE
-   NUMBER(String)
-   STRING(String)
-   LBRACE
-   RBRACE
-   LBRACKET
-   RBRACKET
-   COMMA
-   COLON
-   TRUE
-   FALSE
-   NULL
- } derive(ToJson)
+  WHITESPACE
+  NUMBER(String)
+  STRING(String)
+  LBRACE
+  RBRACE
+  LBRACKET
+  RBRACKET
+  COMMA
+  COLON
+  TRUE
+  FALSE
+  NULL
+} derive(ToJson)
 
 pub type! LexError {
-   EndOfFile
-   UnexpectedEndOfFile
-   Unrecognized(String)
- }
+  EndOfFile
+  UnexpectedEndOfFile
+  Unrecognized(String)
+}
 
 
 let token_tag_action_row_0 : Array[Int] = []
@@ -133,305 +132,305 @@ let token_tag_action_5 : Array[Array[Int]] = [token_tag_action_row_1, token_tag_
 let token_tag_action_3 : Array[Array[Int]] = [token_tag_action_row_1, token_tag_action_row_2, token_tag_action_row_0, token_tag_action_row_0, token_tag_action_row_1, token_tag_action_row_2]
 
 fn token_state_0(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     0..=8 => (2, token_tag_action_0)
-     9..=10 => (12, token_tag_action_0)
-     11..=12 => (2, token_tag_action_0)
-     13 => (12, token_tag_action_0)
-     14..=31 => (2, token_tag_action_0)
-     32 => (12, token_tag_action_0)
-     33 => (2, token_tag_action_0)
-     34 => (1, token_tag_action_1)
-     35..=43 => (2, token_tag_action_0)
-     44 => (7, token_tag_action_0)
-     45 => (13, token_tag_action_2)
-     46..=47 => (2, token_tag_action_0)
-     48 => (15, token_tag_action_3)
-     49..=57 => (14, token_tag_action_3)
-     58 => (6, token_tag_action_0)
-     59..=90 => (2, token_tag_action_0)
-     91 => (9, token_tag_action_0)
-     92 => (2, token_tag_action_0)
-     93 => (8, token_tag_action_0)
-     94..=101 => (2, token_tag_action_0)
-     102 => (4, token_tag_action_0)
-     103..=109 => (2, token_tag_action_0)
-     110 => (3, token_tag_action_0)
-     111..=115 => (2, token_tag_action_0)
-     116 => (5, token_tag_action_0)
-     117..=122 => (2, token_tag_action_0)
-     123 => (11, token_tag_action_0)
-     124 => (2, token_tag_action_0)
-     125 => (10, token_tag_action_0)
-     126..=1114111 => (2, token_tag_action_0)
-     _ => (-1, [])
-   }
- }
+  match input {
+    0..=8 => (2, token_tag_action_0)
+    9..=10 => (12, token_tag_action_0)
+    11..=12 => (2, token_tag_action_0)
+    13 => (12, token_tag_action_0)
+    14..=31 => (2, token_tag_action_0)
+    32 => (12, token_tag_action_0)
+    33 => (2, token_tag_action_0)
+    34 => (1, token_tag_action_1)
+    35..=43 => (2, token_tag_action_0)
+    44 => (7, token_tag_action_0)
+    45 => (13, token_tag_action_2)
+    46..=47 => (2, token_tag_action_0)
+    48 => (15, token_tag_action_3)
+    49..=57 => (14, token_tag_action_3)
+    58 => (6, token_tag_action_0)
+    59..=90 => (2, token_tag_action_0)
+    91 => (9, token_tag_action_0)
+    92 => (2, token_tag_action_0)
+    93 => (8, token_tag_action_0)
+    94..=101 => (2, token_tag_action_0)
+    102 => (4, token_tag_action_0)
+    103..=109 => (2, token_tag_action_0)
+    110 => (3, token_tag_action_0)
+    111..=115 => (2, token_tag_action_0)
+    116 => (5, token_tag_action_0)
+    117..=122 => (2, token_tag_action_0)
+    123 => (11, token_tag_action_0)
+    124 => (2, token_tag_action_0)
+    125 => (10, token_tag_action_0)
+    126..=1114111 => (2, token_tag_action_0)
+    _ => (-1, [])
+  }
+}
 fn token_state_1(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     _ => (-1, [])
-   }
- }
+  match input {
+    _ => (-1, [])
+  }
+}
 fn token_state_2(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     _ => (-1, [])
-   }
- }
+  match input {
+    _ => (-1, [])
+  }
+}
 fn token_state_3(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     117 => (16, token_tag_action_4)
-     _ => (-1, [])
-   }
- }
+  match input {
+    117 => (16, token_tag_action_4)
+    _ => (-1, [])
+  }
+}
 fn token_state_4(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     97 => (17, token_tag_action_4)
-     _ => (-1, [])
-   }
- }
+  match input {
+    97 => (17, token_tag_action_4)
+    _ => (-1, [])
+  }
+}
 fn token_state_5(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     114 => (18, token_tag_action_4)
-     _ => (-1, [])
-   }
- }
+  match input {
+    114 => (18, token_tag_action_4)
+    _ => (-1, [])
+  }
+}
 fn token_state_6(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     _ => (-1, [])
-   }
- }
+  match input {
+    _ => (-1, [])
+  }
+}
 fn token_state_7(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     _ => (-1, [])
-   }
- }
+  match input {
+    _ => (-1, [])
+  }
+}
 fn token_state_8(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     _ => (-1, [])
-   }
- }
+  match input {
+    _ => (-1, [])
+  }
+}
 fn token_state_9(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     _ => (-1, [])
-   }
- }
+  match input {
+    _ => (-1, [])
+  }
+}
 fn token_state_10(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     _ => (-1, [])
-   }
- }
+  match input {
+    _ => (-1, [])
+  }
+}
 fn token_state_11(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     _ => (-1, [])
-   }
- }
+  match input {
+    _ => (-1, [])
+  }
+}
 fn token_state_12(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     _ => (-1, [])
-   }
- }
+  match input {
+    _ => (-1, [])
+  }
+}
 fn token_state_13(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     48 => (20, token_tag_action_5)
-     49..=57 => (19, token_tag_action_5)
-     _ => (-1, [])
-   }
- }
+  match input {
+    48 => (20, token_tag_action_5)
+    49..=57 => (19, token_tag_action_5)
+    _ => (-1, [])
+  }
+}
 fn token_state_14(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     46 => (22, token_tag_action_6)
-     48..=57 => (23, token_tag_action_5)
-     69 => (21, token_tag_action_6)
-     101 => (21, token_tag_action_6)
-     _ => (-1, [])
-   }
- }
+  match input {
+    46 => (22, token_tag_action_6)
+    48..=57 => (23, token_tag_action_5)
+    69 => (21, token_tag_action_6)
+    101 => (21, token_tag_action_6)
+    _ => (-1, [])
+  }
+}
 fn token_state_15(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     69 => (21, token_tag_action_6)
-     101 => (21, token_tag_action_6)
-     _ => (-1, [])
-   }
- }
+  match input {
+    69 => (21, token_tag_action_6)
+    101 => (21, token_tag_action_6)
+    _ => (-1, [])
+  }
+}
 fn token_state_16(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     108 => (24, token_tag_action_4)
-     _ => (-1, [])
-   }
- }
+  match input {
+    108 => (24, token_tag_action_4)
+    _ => (-1, [])
+  }
+}
 fn token_state_17(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     108 => (25, token_tag_action_4)
-     _ => (-1, [])
-   }
- }
+  match input {
+    108 => (25, token_tag_action_4)
+    _ => (-1, [])
+  }
+}
 fn token_state_18(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     117 => (26, token_tag_action_4)
-     _ => (-1, [])
-   }
- }
+  match input {
+    117 => (26, token_tag_action_4)
+    _ => (-1, [])
+  }
+}
 fn token_state_19(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     46 => (22, token_tag_action_6)
-     48..=57 => (23, token_tag_action_5)
-     69 => (21, token_tag_action_6)
-     101 => (21, token_tag_action_6)
-     _ => (-1, [])
-   }
- }
+  match input {
+    46 => (22, token_tag_action_6)
+    48..=57 => (23, token_tag_action_5)
+    69 => (21, token_tag_action_6)
+    101 => (21, token_tag_action_6)
+    _ => (-1, [])
+  }
+}
 fn token_state_20(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     69 => (21, token_tag_action_6)
-     101 => (21, token_tag_action_6)
-     _ => (-1, [])
-   }
- }
+  match input {
+    69 => (21, token_tag_action_6)
+    101 => (21, token_tag_action_6)
+    _ => (-1, [])
+  }
+}
 fn token_state_21(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     43 => (28, token_tag_action_6)
-     45 => (28, token_tag_action_6)
-     48..=57 => (27, token_tag_action_5)
-     _ => (-1, [])
-   }
- }
+  match input {
+    43 => (28, token_tag_action_6)
+    45 => (28, token_tag_action_6)
+    48..=57 => (27, token_tag_action_5)
+    _ => (-1, [])
+  }
+}
 fn token_state_22(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     48..=57 => (29, token_tag_action_5)
-     _ => (-1, [])
-   }
- }
+  match input {
+    48..=57 => (29, token_tag_action_5)
+    _ => (-1, [])
+  }
+}
 fn token_state_23(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     46 => (22, token_tag_action_6)
-     48..=57 => (23, token_tag_action_5)
-     69 => (21, token_tag_action_6)
-     101 => (21, token_tag_action_6)
-     _ => (-1, [])
-   }
- }
+  match input {
+    46 => (22, token_tag_action_6)
+    48..=57 => (23, token_tag_action_5)
+    69 => (21, token_tag_action_6)
+    101 => (21, token_tag_action_6)
+    _ => (-1, [])
+  }
+}
 fn token_state_24(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     108 => (30, token_tag_action_4)
-     _ => (-1, [])
-   }
- }
+  match input {
+    108 => (30, token_tag_action_4)
+    _ => (-1, [])
+  }
+}
 fn token_state_25(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     115 => (31, token_tag_action_4)
-     _ => (-1, [])
-   }
- }
+  match input {
+    115 => (31, token_tag_action_4)
+    _ => (-1, [])
+  }
+}
 fn token_state_26(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     101 => (32, token_tag_action_4)
-     _ => (-1, [])
-   }
- }
+  match input {
+    101 => (32, token_tag_action_4)
+    _ => (-1, [])
+  }
+}
 fn token_state_27(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     48..=57 => (27, token_tag_action_5)
-     _ => (-1, [])
-   }
- }
+  match input {
+    48..=57 => (27, token_tag_action_5)
+    _ => (-1, [])
+  }
+}
 fn token_state_28(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     48..=57 => (27, token_tag_action_5)
-     _ => (-1, [])
-   }
- }
+  match input {
+    48..=57 => (27, token_tag_action_5)
+    _ => (-1, [])
+  }
+}
 fn token_state_29(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     48..=57 => (29, token_tag_action_5)
-     69 => (21, token_tag_action_6)
-     101 => (21, token_tag_action_6)
-     _ => (-1, [])
-   }
- }
+  match input {
+    48..=57 => (29, token_tag_action_5)
+    69 => (21, token_tag_action_6)
+    101 => (21, token_tag_action_6)
+    _ => (-1, [])
+  }
+}
 fn token_state_30(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     _ => (-1, [])
-   }
- }
+  match input {
+    _ => (-1, [])
+  }
+}
 fn token_state_31(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     101 => (33, token_tag_action_4)
-     _ => (-1, [])
-   }
- }
+  match input {
+    101 => (33, token_tag_action_4)
+    _ => (-1, [])
+  }
+}
 fn token_state_32(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     _ => (-1, [])
-   }
- }
+  match input {
+    _ => (-1, [])
+  }
+}
 fn token_state_33(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     _ => (-1, [])
-   }
- }
+  match input {
+    _ => (-1, [])
+  }
+}
 
 let __mbtlex_engine_token: LexEngine = { graph: [token_state_0, token_state_1, token_state_2, token_state_3, token_state_4, token_state_5, token_state_6, token_state_7, token_state_8, token_state_9, token_state_10, token_state_11, token_state_12, token_state_13, token_state_14, token_state_15, token_state_16, token_state_17, token_state_18, token_state_19, token_state_20, token_state_21, token_state_22, token_state_23, token_state_24, token_state_25, token_state_26, token_state_27, token_state_28, token_state_29, token_state_30, token_state_31, token_state_32, token_state_33, ], end_nodes: [Some((13, [])), Some((2, [((2, 0), (3, 0))])), Some((12, [((4, 0), (5, 0))])), Some((12, [((4, 0), (5, 0))])), Some((12, [((4, 0), (5, 0))])), Some((12, [((4, 0), (5, 0))])), Some((8, [])), Some((7, [])), Some((6, [])), Some((5, [])), Some((4, [])), Some((3, [])), Some((0, [])), Some((12, [((4, 0), (5, 0))])), Some((1, [((0, 0), (1, 0))])), Some((1, [((0, 0), (1, 0))])), None, None, None, Some((1, [((0, 0), (1, 0))])), Some((1, [((0, 0), (1, 0))])), None, None, Some((1, [((0, 0), (1, 0))])), None, None, None, Some((1, [((0, 0), (1, 0))])), None, Some((1, [((0, 0), (1, 0))])), Some((11, [])), None, Some((9, [])), Some((10, []))], start_tags: [0, 2, 4], code_blocks_n: 14 }
 fn token( lexbuf : Lexbuf ) ->  Token!LexError  {
- match __mbtlex_engine_token.run(lexbuf) {
- (0, __mbtlex_captures) => {
-  WHITESPACE 
- }
- (1, __mbtlex_captures) => {
- let (_start_pos_of_t, _end_pos_of_t) = __mbtlex_captures[0]
- let t: String = lexbuf.substring(_start_pos_of_t, _end_pos_of_t)
- 
-  NUMBER(t) 
- }
- (2, __mbtlex_captures) => {
- let (_start_pos_of_t, _end_pos_of_t) = __mbtlex_captures[0]
- let t: String = lexbuf.substring(_start_pos_of_t, _end_pos_of_t)
- 
- 
-       let buf = StringBuilder::new()
-       buf.write_string(t)
-       lex_string!(buf, lexbuf)
-       STRING(buf.to_string())
-     
- }
- (3, __mbtlex_captures) => {
-  LBRACE 
- }
- (4, __mbtlex_captures) => {
-  RBRACE 
- }
- (5, __mbtlex_captures) => {
-  LBRACKET 
- }
- (6, __mbtlex_captures) => {
-  RBRACKET 
- }
- (7, __mbtlex_captures) => {
-  COMMA 
- }
- (8, __mbtlex_captures) => {
-  COLON 
- }
- (9, __mbtlex_captures) => {
-  TRUE 
- }
- (10, __mbtlex_captures) => {
-  FALSE 
- }
- (11, __mbtlex_captures) => {
-  NULL 
- }
- (12, __mbtlex_captures) => {
- let (_start_pos_of_t, _end_pos_of_t) = __mbtlex_captures[0]
- let t: String = lexbuf.substring(_start_pos_of_t, _end_pos_of_t)
- 
-  raise(Unrecognized(t)) 
- }
- (13, __mbtlex_captures) => {
-  raise(EndOfFile) 
- }
- _ => abort("lex: fail to match")
- }
- }
+  match __mbtlex_engine_token.run(lexbuf) {
+    (0, __mbtlex_captures) => {
+ WHITESPACE 
+    }
+    (1, __mbtlex_captures) => {
+  let (_start_pos_of_t, _end_pos_of_t) = __mbtlex_captures[0]
+  let t: String = lexbuf.substring(_start_pos_of_t, _end_pos_of_t)
+  
+ NUMBER(t) 
+    }
+    (2, __mbtlex_captures) => {
+  let (_start_pos_of_t, _end_pos_of_t) = __mbtlex_captures[0]
+  let t: String = lexbuf.substring(_start_pos_of_t, _end_pos_of_t)
+  
+
+      let buf = StringBuilder::new()
+      buf.write_string(t)
+      lex_string!(buf, lexbuf)
+      STRING(buf.to_string())
+    
+    }
+    (3, __mbtlex_captures) => {
+ LBRACE 
+    }
+    (4, __mbtlex_captures) => {
+ RBRACE 
+    }
+    (5, __mbtlex_captures) => {
+ LBRACKET 
+    }
+    (6, __mbtlex_captures) => {
+ RBRACKET 
+    }
+    (7, __mbtlex_captures) => {
+ COMMA 
+    }
+    (8, __mbtlex_captures) => {
+ COLON 
+    }
+    (9, __mbtlex_captures) => {
+ TRUE 
+    }
+    (10, __mbtlex_captures) => {
+ FALSE 
+    }
+    (11, __mbtlex_captures) => {
+ NULL 
+    }
+    (12, __mbtlex_captures) => {
+  let (_start_pos_of_t, _end_pos_of_t) = __mbtlex_captures[0]
+  let t: String = lexbuf.substring(_start_pos_of_t, _end_pos_of_t)
+  
+ raise(Unrecognized(t)) 
+    }
+    (13, __mbtlex_captures) => {
+ raise(EndOfFile) 
+    }
+    _ => abort("lex: fail to match")
+  }
+}
 let lex_string_tag_action_row_0 : Array[Int] = []
 let lex_string_tag_action_row_2 : Array[Int] = [-1]
 let lex_string_tag_action_row_1 : Array[Int] = [0]
@@ -444,205 +443,205 @@ let lex_string_tag_action_4 : Array[Array[Int]] = [lex_string_tag_action_row_0, 
 let lex_string_tag_action_2 : Array[Array[Int]] = [lex_string_tag_action_row_1, lex_string_tag_action_row_2, lex_string_tag_action_row_0, lex_string_tag_action_row_0, lex_string_tag_action_row_0, lex_string_tag_action_row_0, lex_string_tag_action_row_1, lex_string_tag_action_row_2]
 
 fn lex_string_state_0(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     0..=31 => (3, lex_string_tag_action_0)
-     32..=33 => (2, lex_string_tag_action_1)
-     34 => (1, lex_string_tag_action_2)
-     35..=91 => (2, lex_string_tag_action_1)
-     92 => (4, lex_string_tag_action_3)
-     93..=126 => (2, lex_string_tag_action_1)
-     127 => (3, lex_string_tag_action_0)
-     128..=1114111 => (2, lex_string_tag_action_1)
-     _ => (-1, [])
-   }
- }
+  match input {
+    0..=31 => (3, lex_string_tag_action_0)
+    32..=33 => (2, lex_string_tag_action_1)
+    34 => (1, lex_string_tag_action_2)
+    35..=91 => (2, lex_string_tag_action_1)
+    92 => (4, lex_string_tag_action_3)
+    93..=126 => (2, lex_string_tag_action_1)
+    127 => (3, lex_string_tag_action_0)
+    128..=1114111 => (2, lex_string_tag_action_1)
+    _ => (-1, [])
+  }
+}
 fn lex_string_state_1(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     _ => (-1, [])
-   }
- }
+  match input {
+    _ => (-1, [])
+  }
+}
 fn lex_string_state_2(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     _ => (-1, [])
-   }
- }
+  match input {
+    _ => (-1, [])
+  }
+}
 fn lex_string_state_3(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     _ => (-1, [])
-   }
- }
+  match input {
+    _ => (-1, [])
+  }
+}
 fn lex_string_state_4(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     34 => (6, lex_string_tag_action_4)
-     92 => (5, lex_string_tag_action_5)
-     _ => (-1, [])
-   }
- }
+  match input {
+    34 => (6, lex_string_tag_action_4)
+    92 => (5, lex_string_tag_action_5)
+    _ => (-1, [])
+  }
+}
 fn lex_string_state_5(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     92 => (7, lex_string_tag_action_4)
-     _ => (-1, [])
-   }
- }
+  match input {
+    92 => (7, lex_string_tag_action_4)
+    _ => (-1, [])
+  }
+}
 fn lex_string_state_6(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     _ => (-1, [])
-   }
- }
+  match input {
+    _ => (-1, [])
+  }
+}
 fn lex_string_state_7(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     47 => (9, lex_string_tag_action_4)
-     92 => (8, lex_string_tag_action_5)
-     _ => (-1, [])
-   }
- }
+  match input {
+    47 => (9, lex_string_tag_action_4)
+    92 => (8, lex_string_tag_action_5)
+    _ => (-1, [])
+  }
+}
 fn lex_string_state_8(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     92 => (10, lex_string_tag_action_5)
-     98 => (11, lex_string_tag_action_4)
-     _ => (-1, [])
-   }
- }
+  match input {
+    92 => (10, lex_string_tag_action_5)
+    98 => (11, lex_string_tag_action_4)
+    _ => (-1, [])
+  }
+}
 fn lex_string_state_9(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     _ => (-1, [])
-   }
- }
+  match input {
+    _ => (-1, [])
+  }
+}
 fn lex_string_state_10(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     92 => (12, lex_string_tag_action_5)
-     102 => (13, lex_string_tag_action_4)
-     _ => (-1, [])
-   }
- }
+  match input {
+    92 => (12, lex_string_tag_action_5)
+    102 => (13, lex_string_tag_action_4)
+    _ => (-1, [])
+  }
+}
 fn lex_string_state_11(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     _ => (-1, [])
-   }
- }
+  match input {
+    _ => (-1, [])
+  }
+}
 fn lex_string_state_12(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     92 => (14, lex_string_tag_action_5)
-     110 => (15, lex_string_tag_action_4)
-     _ => (-1, [])
-   }
- }
+  match input {
+    92 => (14, lex_string_tag_action_5)
+    110 => (15, lex_string_tag_action_4)
+    _ => (-1, [])
+  }
+}
 fn lex_string_state_13(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     _ => (-1, [])
-   }
- }
+  match input {
+    _ => (-1, [])
+  }
+}
 fn lex_string_state_14(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     92 => (16, lex_string_tag_action_5)
-     114 => (17, lex_string_tag_action_4)
-     _ => (-1, [])
-   }
- }
+  match input {
+    92 => (16, lex_string_tag_action_5)
+    114 => (17, lex_string_tag_action_4)
+    _ => (-1, [])
+  }
+}
 fn lex_string_state_15(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     _ => (-1, [])
-   }
- }
+  match input {
+    _ => (-1, [])
+  }
+}
 fn lex_string_state_16(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     92 => (18, lex_string_tag_action_5)
-     116 => (19, lex_string_tag_action_4)
-     _ => (-1, [])
-   }
- }
+  match input {
+    92 => (18, lex_string_tag_action_5)
+    116 => (19, lex_string_tag_action_4)
+    _ => (-1, [])
+  }
+}
 fn lex_string_state_17(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     _ => (-1, [])
-   }
- }
+  match input {
+    _ => (-1, [])
+  }
+}
 fn lex_string_state_18(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     117 => (20, lex_string_tag_action_5)
-     _ => (-1, [])
-   }
- }
+  match input {
+    117 => (20, lex_string_tag_action_5)
+    _ => (-1, [])
+  }
+}
 fn lex_string_state_19(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     _ => (-1, [])
-   }
- }
+  match input {
+    _ => (-1, [])
+  }
+}
 fn lex_string_state_20(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     48..=57 => (21, lex_string_tag_action_5)
-     65..=70 => (21, lex_string_tag_action_5)
-     97..=102 => (21, lex_string_tag_action_5)
-     _ => (-1, [])
-   }
- }
+  match input {
+    48..=57 => (21, lex_string_tag_action_5)
+    65..=70 => (21, lex_string_tag_action_5)
+    97..=102 => (21, lex_string_tag_action_5)
+    _ => (-1, [])
+  }
+}
 fn lex_string_state_21(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     48..=57 => (22, lex_string_tag_action_5)
-     65..=70 => (22, lex_string_tag_action_5)
-     97..=102 => (22, lex_string_tag_action_5)
-     _ => (-1, [])
-   }
- }
+  match input {
+    48..=57 => (22, lex_string_tag_action_5)
+    65..=70 => (22, lex_string_tag_action_5)
+    97..=102 => (22, lex_string_tag_action_5)
+    _ => (-1, [])
+  }
+}
 fn lex_string_state_22(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     48..=57 => (23, lex_string_tag_action_5)
-     65..=70 => (23, lex_string_tag_action_5)
-     97..=102 => (23, lex_string_tag_action_5)
-     _ => (-1, [])
-   }
- }
+  match input {
+    48..=57 => (23, lex_string_tag_action_5)
+    65..=70 => (23, lex_string_tag_action_5)
+    97..=102 => (23, lex_string_tag_action_5)
+    _ => (-1, [])
+  }
+}
 fn lex_string_state_23(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     48..=57 => (24, lex_string_tag_action_4)
-     65..=70 => (24, lex_string_tag_action_4)
-     97..=102 => (24, lex_string_tag_action_4)
-     _ => (-1, [])
-   }
- }
+  match input {
+    48..=57 => (24, lex_string_tag_action_4)
+    65..=70 => (24, lex_string_tag_action_4)
+    97..=102 => (24, lex_string_tag_action_4)
+    _ => (-1, [])
+  }
+}
 fn lex_string_state_24(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     _ => (-1, [])
-   }
- }
+  match input {
+    _ => (-1, [])
+  }
+}
 
 let __mbtlex_engine_lex_string: LexEngine = { graph: [lex_string_state_0, lex_string_state_1, lex_string_state_2, lex_string_state_3, lex_string_state_4, lex_string_state_5, lex_string_state_6, lex_string_state_7, lex_string_state_8, lex_string_state_9, lex_string_state_10, lex_string_state_11, lex_string_state_12, lex_string_state_13, lex_string_state_14, lex_string_state_15, lex_string_state_16, lex_string_state_17, lex_string_state_18, lex_string_state_19, lex_string_state_20, lex_string_state_21, lex_string_state_22, lex_string_state_23, lex_string_state_24, ], end_nodes: [Some((4, [])), Some((0, [((0, 0), (1, 0))])), Some((2, [((4, 0), (5, 0))])), Some((3, [((6, 0), (7, 0))])), Some((3, [((6, 0), (7, 0))])), None, Some((1, [((2, 0), (3, 0))])), Some((1, [((2, 0), (3, 0))])), None, Some((1, [((2, 0), (3, 0))])), None, Some((1, [((2, 0), (3, 0))])), None, Some((1, [((2, 0), (3, 0))])), None, Some((1, [((2, 0), (3, 0))])), None, Some((1, [((2, 0), (3, 0))])), None, Some((1, [((2, 0), (3, 0))])), None, None, None, None, Some((1, [((2, 0), (3, 0))]))], start_tags: [0, 2, 4, 6], code_blocks_n: 5 }
 fn lex_string( buf :  StringBuilder, lexbuf : Lexbuf ) ->  Unit!LexError  {
- match __mbtlex_engine_lex_string.run(lexbuf) {
- (0, __mbtlex_captures) => {
- let (_start_pos_of_t, _end_pos_of_t) = __mbtlex_captures[0]
- let t: String = lexbuf.substring(_start_pos_of_t, _end_pos_of_t)
- 
-  buf.write_string(t) 
- }
- (1, __mbtlex_captures) => {
- let (_start_pos_of_t, _end_pos_of_t) = __mbtlex_captures[0]
- let t: String = lexbuf.substring(_start_pos_of_t, _end_pos_of_t)
- 
+  match __mbtlex_engine_lex_string.run(lexbuf) {
+    (0, __mbtlex_captures) => {
+  let (_start_pos_of_t, _end_pos_of_t) = __mbtlex_captures[0]
+  let t: String = lexbuf.substring(_start_pos_of_t, _end_pos_of_t)
   
-       buf.write_string(t)
-       lex_string!(buf, lexbuf)
-     
- }
- (2, __mbtlex_captures) => {
- let (_start_pos_of_t, _end_pos_of_t) = __mbtlex_captures[0]
- let t: String = lexbuf.substring(_start_pos_of_t, _end_pos_of_t)
- 
+ buf.write_string(t) 
+    }
+    (1, __mbtlex_captures) => {
+  let (_start_pos_of_t, _end_pos_of_t) = __mbtlex_captures[0]
+  let t: String = lexbuf.substring(_start_pos_of_t, _end_pos_of_t)
   
-       buf.write_string(t)
-       lex_string!(buf, lexbuf)
-     
- }
- (3, __mbtlex_captures) => {
- let (_start_pos_of_t, _end_pos_of_t) = __mbtlex_captures[0]
- let t: String = lexbuf.substring(_start_pos_of_t, _end_pos_of_t)
  
-  raise(Unrecognized(t)) 
- }
- (4, __mbtlex_captures) => {
-  raise(UnexpectedEndOfFile) 
- }
- _ => abort("lex: fail to match")
- }
- }
+      buf.write_string(t)
+      lex_string!(buf, lexbuf)
+    
+    }
+    (2, __mbtlex_captures) => {
+  let (_start_pos_of_t, _end_pos_of_t) = __mbtlex_captures[0]
+  let t: String = lexbuf.substring(_start_pos_of_t, _end_pos_of_t)
+  
+ 
+      buf.write_string(t)
+      lex_string!(buf, lexbuf)
+    
+    }
+    (3, __mbtlex_captures) => {
+  let (_start_pos_of_t, _end_pos_of_t) = __mbtlex_captures[0]
+  let t: String = lexbuf.substring(_start_pos_of_t, _end_pos_of_t)
+  
+ raise(Unrecognized(t)) 
+    }
+    (4, __mbtlex_captures) => {
+ raise(UnexpectedEndOfFile) 
+    }
+    _ => abort("lex: fail to match")
+  }
+}
 
 

--- a/src/tests/named_regexes/named_regexes.mbt
+++ b/src/tests/named_regexes/named_regexes.mbt
@@ -1,31 +1,30 @@
-
 ///|
 struct Lexbuf {
-   content : String
-   mut pos : Int
- }
+  content : String
+  mut pos : Int
+}
 
 ///|
 pub fn Lexbuf::from_string(content : String) -> Lexbuf {
-   { content, pos: 0 }
- }
+  { content, pos: 0 }
+}
 
 // NOTE: MoonBit do have unboxed Option[Char] optimization
 ///|
 fn next(self : Lexbuf) -> Char? {
-   if self.pos < self.content.length() {
-     let ch = self.content[self.pos]
-     self.pos += 1
-     Some(ch)
-   } else {
-     None
-   }
- }
+  if self.pos < self.content.length() {
+    let ch = self.content[self.pos]
+    self.pos += 1
+    Some(ch)
+  } else {
+    None
+  }
+}
 
 ///|
 fn substring(self : Lexbuf, start : Int, end : Int) -> String {
-   self.content.substring(start~, end~)
- }
+  self.content.substring(start~, end~)
+}
 
 ///|
 typealias LexTagAction = Array[Array[Int]]
@@ -38,63 +37,63 @@ typealias LexInput = Int
 
 ///|
 pub(all) struct LexEngine {
-   graph : Array[(LexState) -> (LexState, LexTagAction)]
-   end_nodes : Array[(Int, Array[((Int, Int), (Int, Int))])?]
-   start_tags : Array[Int]
-   code_blocks_n : Int
- }
+  graph : Array[(LexState) -> (LexState, LexTagAction)]
+  end_nodes : Array[(Int, Array[((Int, Int), (Int, Int))])?]
+  start_tags : Array[Int]
+  code_blocks_n : Int
+}
 
 ///|
 pub fn run(self : LexEngine, lexbuf : Lexbuf) -> (Int, Array[(Int, Int)]) {
-   let mut state = 0
-   let mut tagState : Array[Array[Int]] = []
-   let backtrace = Array::make(self.code_blocks_n, None)
-   for tag in self.start_tags {
-     while tagState.length() <= tag {
-       tagState.push([])
-     }
-     tagState[tag].push(lexbuf.pos)
-   }
-   while state != -1 {
-     match self.end_nodes[state] {
-       Some(t) => backtrace[t.0] = Some((lexbuf.pos, state, tagState))
-       _ => ()
-     }
-     let b = match lexbuf.next() {
-       Some(b) => b.to_int()
-       None => -1
-     }
-     let next = self.graph[state](b)
-     state = next.0
-     let new_tagState : Array[Array[Int]] = []
-     for i = 0; i < next.1.length(); i = i + 1 {
-       new_tagState.push([])
-       for j = 0; j < next.1[i].length(); j = j + 1 {
-         let t = next.1[i][j]
-         if t == -1 {
-           new_tagState[i].push(lexbuf.pos)
-         } else {
-           new_tagState[i].push(tagState[i][t])
-         }
-       }
-     }
-     tagState = new_tagState
-   }
-   for index, b in backtrace {
-     match b {
-       Some((p, state, tagState)) => {
-         lexbuf.pos = p
-         let captures = self.end_nodes[state].unwrap().1.map(fn {
-           ((b_t, b_r), (e_t, e_r)) => (tagState[b_t][b_r], tagState[e_t][e_r])
-         })
-         break (index, captures)
-       }
-       None => ()
-     }
-   } else {
-     (self.code_blocks_n, [])
-   }
- }
+  let mut state = 0
+  let mut tagState : Array[Array[Int]] = []
+  let backtrace = Array::make(self.code_blocks_n, None)
+  for tag in self.start_tags {
+    while tagState.length() <= tag {
+      tagState.push([])
+    }
+    tagState[tag].push(lexbuf.pos)
+  }
+  while state != -1 {
+    match self.end_nodes[state] {
+      Some(t) => backtrace[t.0] = Some((lexbuf.pos, state, tagState))
+      _ => ()
+    }
+    let b = match lexbuf.next() {
+      Some(b) => b.to_int()
+      None => -1
+    }
+    let next = self.graph[state](b)
+    state = next.0
+    let new_tagState : Array[Array[Int]] = []
+    for i = 0; i < next.1.length(); i = i + 1 {
+      new_tagState.push([])
+      for j = 0; j < next.1[i].length(); j = j + 1 {
+        let t = next.1[i][j]
+        if t == -1 {
+          new_tagState[i].push(lexbuf.pos)
+        } else {
+          new_tagState[i].push(tagState[i][t])
+        }
+      }
+    }
+    tagState = new_tagState
+  }
+  for index, b in backtrace {
+    match b {
+      Some((p, state, tagState)) => {
+        lexbuf.pos = p
+        let captures = self.end_nodes[state].unwrap().1.map(fn {
+          ((b_t, b_r), (e_t, e_r)) => (tagState[b_t][b_r], tagState[e_t][e_r])
+        })
+        break (index, captures)
+      }
+      None => ()
+    }
+  } else {
+    (self.code_blocks_n, [])
+  }
+}
 
 
 
@@ -103,52 +102,52 @@ pub fn run(self : LexEngine, lexbuf : Lexbuf) -> (Int, Array[(Int, Int)]) {
 let lex_is_number_tag_action_0 : Array[Array[Int]] = []
 
 fn lex_is_number_state_0(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     0..=47 => (1, lex_is_number_tag_action_0)
-     48 => (3, lex_is_number_tag_action_0)
-     49..=57 => (2, lex_is_number_tag_action_0)
-     58..=1114111 => (1, lex_is_number_tag_action_0)
-     _ => (-1, [])
-   }
- }
+  match input {
+    0..=47 => (1, lex_is_number_tag_action_0)
+    48 => (3, lex_is_number_tag_action_0)
+    49..=57 => (2, lex_is_number_tag_action_0)
+    58..=1114111 => (1, lex_is_number_tag_action_0)
+    _ => (-1, [])
+  }
+}
 fn lex_is_number_state_1(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     _ => (-1, [])
-   }
- }
+  match input {
+    _ => (-1, [])
+  }
+}
 fn lex_is_number_state_2(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     48..=57 => (4, lex_is_number_tag_action_0)
-     _ => (-1, [])
-   }
- }
+  match input {
+    48..=57 => (4, lex_is_number_tag_action_0)
+    _ => (-1, [])
+  }
+}
 fn lex_is_number_state_3(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     _ => (-1, [])
-   }
- }
+  match input {
+    _ => (-1, [])
+  }
+}
 fn lex_is_number_state_4(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     48..=57 => (4, lex_is_number_tag_action_0)
-     _ => (-1, [])
-   }
- }
+  match input {
+    48..=57 => (4, lex_is_number_tag_action_0)
+    _ => (-1, [])
+  }
+}
 
 let __mbtlex_engine_lex_is_number: LexEngine = { graph: [lex_is_number_state_0, lex_is_number_state_1, lex_is_number_state_2, lex_is_number_state_3, lex_is_number_state_4, ], end_nodes: [None, Some((1, [])), Some((0, [])), Some((0, [])), Some((0, []))], start_tags: [], code_blocks_n: 2 }
 fn lex_is_number( lexbuf : Lexbuf ) ->  Bool  {
- match __mbtlex_engine_lex_is_number.run(lexbuf) {
- (0, __mbtlex_captures) => {
-  true 
- }
- (1, __mbtlex_captures) => {
-  false 
- }
- _ => abort("lex: fail to match")
- }
- }
+  match __mbtlex_engine_lex_is_number.run(lexbuf) {
+    (0, __mbtlex_captures) => {
+ true 
+    }
+    (1, __mbtlex_captures) => {
+ false 
+    }
+    _ => abort("lex: fail to match")
+  }
+}
 
 
 pub fn is_number(str : String) -> Bool {
-     let lexbuf = Lexbuf::from_string(str)
-     lex_is_number(lexbuf)
- }
+    let lexbuf = Lexbuf::from_string(str)
+    lex_is_number(lexbuf)
+}

--- a/src/tests/wordcountlexer/wordcountlexer.mbt
+++ b/src/tests/wordcountlexer/wordcountlexer.mbt
@@ -1,31 +1,30 @@
-
 ///|
 struct Lexbuf {
-   content : String
-   mut pos : Int
- }
+  content : String
+  mut pos : Int
+}
 
 ///|
 pub fn Lexbuf::from_string(content : String) -> Lexbuf {
-   { content, pos: 0 }
- }
+  { content, pos: 0 }
+}
 
 // NOTE: MoonBit do have unboxed Option[Char] optimization
 ///|
 fn next(self : Lexbuf) -> Char? {
-   if self.pos < self.content.length() {
-     let ch = self.content[self.pos]
-     self.pos += 1
-     Some(ch)
-   } else {
-     None
-   }
- }
+  if self.pos < self.content.length() {
+    let ch = self.content[self.pos]
+    self.pos += 1
+    Some(ch)
+  } else {
+    None
+  }
+}
 
 ///|
 fn substring(self : Lexbuf, start : Int, end : Int) -> String {
-   self.content.substring(start~, end~)
- }
+  self.content.substring(start~, end~)
+}
 
 ///|
 typealias LexTagAction = Array[Array[Int]]
@@ -38,63 +37,63 @@ typealias LexInput = Int
 
 ///|
 pub(all) struct LexEngine {
-   graph : Array[(LexState) -> (LexState, LexTagAction)]
-   end_nodes : Array[(Int, Array[((Int, Int), (Int, Int))])?]
-   start_tags : Array[Int]
-   code_blocks_n : Int
- }
+  graph : Array[(LexState) -> (LexState, LexTagAction)]
+  end_nodes : Array[(Int, Array[((Int, Int), (Int, Int))])?]
+  start_tags : Array[Int]
+  code_blocks_n : Int
+}
 
 ///|
 pub fn run(self : LexEngine, lexbuf : Lexbuf) -> (Int, Array[(Int, Int)]) {
-   let mut state = 0
-   let mut tagState : Array[Array[Int]] = []
-   let backtrace = Array::make(self.code_blocks_n, None)
-   for tag in self.start_tags {
-     while tagState.length() <= tag {
-       tagState.push([])
-     }
-     tagState[tag].push(lexbuf.pos)
-   }
-   while state != -1 {
-     match self.end_nodes[state] {
-       Some(t) => backtrace[t.0] = Some((lexbuf.pos, state, tagState))
-       _ => ()
-     }
-     let b = match lexbuf.next() {
-       Some(b) => b.to_int()
-       None => -1
-     }
-     let next = self.graph[state](b)
-     state = next.0
-     let new_tagState : Array[Array[Int]] = []
-     for i = 0; i < next.1.length(); i = i + 1 {
-       new_tagState.push([])
-       for j = 0; j < next.1[i].length(); j = j + 1 {
-         let t = next.1[i][j]
-         if t == -1 {
-           new_tagState[i].push(lexbuf.pos)
-         } else {
-           new_tagState[i].push(tagState[i][t])
-         }
-       }
-     }
-     tagState = new_tagState
-   }
-   for index, b in backtrace {
-     match b {
-       Some((p, state, tagState)) => {
-         lexbuf.pos = p
-         let captures = self.end_nodes[state].unwrap().1.map(fn {
-           ((b_t, b_r), (e_t, e_r)) => (tagState[b_t][b_r], tagState[e_t][e_r])
-         })
-         break (index, captures)
-       }
-       None => ()
-     }
-   } else {
-     (self.code_blocks_n, [])
-   }
- }
+  let mut state = 0
+  let mut tagState : Array[Array[Int]] = []
+  let backtrace = Array::make(self.code_blocks_n, None)
+  for tag in self.start_tags {
+    while tagState.length() <= tag {
+      tagState.push([])
+    }
+    tagState[tag].push(lexbuf.pos)
+  }
+  while state != -1 {
+    match self.end_nodes[state] {
+      Some(t) => backtrace[t.0] = Some((lexbuf.pos, state, tagState))
+      _ => ()
+    }
+    let b = match lexbuf.next() {
+      Some(b) => b.to_int()
+      None => -1
+    }
+    let next = self.graph[state](b)
+    state = next.0
+    let new_tagState : Array[Array[Int]] = []
+    for i = 0; i < next.1.length(); i = i + 1 {
+      new_tagState.push([])
+      for j = 0; j < next.1[i].length(); j = j + 1 {
+        let t = next.1[i][j]
+        if t == -1 {
+          new_tagState[i].push(lexbuf.pos)
+        } else {
+          new_tagState[i].push(tagState[i][t])
+        }
+      }
+    }
+    tagState = new_tagState
+  }
+  for index, b in backtrace {
+    match b {
+      Some((p, state, tagState)) => {
+        lexbuf.pos = p
+        let captures = self.end_nodes[state].unwrap().1.map(fn {
+          ((b_t, b_r), (e_t, e_r)) => (tagState[b_t][b_r], tagState[e_t][e_r])
+        })
+        break (index, captures)
+      }
+      None => ()
+    }
+  } else {
+    (self.code_blocks_n, [])
+  }
+}
 
 
 
@@ -109,66 +108,66 @@ let count_tag_action_1 : Array[Array[Int]] = [count_tag_action_row_0, count_tag_
 let count_tag_action_0 : Array[Array[Int]] = [count_tag_action_row_1, count_tag_action_row_2]
 
 fn count_state_0(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     0..=8 => (3, count_tag_action_0)
-     9 => (1, count_tag_action_1)
-     10 => (2, count_tag_action_1)
-     11..=31 => (3, count_tag_action_0)
-     32 => (1, count_tag_action_1)
-     33..=1114111 => (3, count_tag_action_0)
-     _ => (-1, [])
-   }
- }
+  match input {
+    0..=8 => (3, count_tag_action_0)
+    9 => (1, count_tag_action_1)
+    10 => (2, count_tag_action_1)
+    11..=31 => (3, count_tag_action_0)
+    32 => (1, count_tag_action_1)
+    33..=1114111 => (3, count_tag_action_0)
+    _ => (-1, [])
+  }
+}
 fn count_state_1(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     _ => (-1, [])
-   }
- }
+  match input {
+    _ => (-1, [])
+  }
+}
 fn count_state_2(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     _ => (-1, [])
-   }
- }
+  match input {
+    _ => (-1, [])
+  }
+}
 fn count_state_3(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     0..=8 => (4, count_tag_action_0)
-     11..=31 => (4, count_tag_action_0)
-     33..=1114111 => (4, count_tag_action_0)
-     _ => (-1, [])
-   }
- }
+  match input {
+    0..=8 => (4, count_tag_action_0)
+    11..=31 => (4, count_tag_action_0)
+    33..=1114111 => (4, count_tag_action_0)
+    _ => (-1, [])
+  }
+}
 fn count_state_4(input : LexInput) -> (LexState, LexTagAction) {
-   match input {
-     0..=8 => (4, count_tag_action_0)
-     11..=31 => (4, count_tag_action_0)
-     33..=1114111 => (4, count_tag_action_0)
-     _ => (-1, [])
-   }
- }
+  match input {
+    0..=8 => (4, count_tag_action_0)
+    11..=31 => (4, count_tag_action_0)
+    33..=1114111 => (4, count_tag_action_0)
+    _ => (-1, [])
+  }
+}
 
 let __mbtlex_engine_count: LexEngine = { graph: [count_state_0, count_state_1, count_state_2, count_state_3, count_state_4, ], end_nodes: [Some((3, [])), Some((2, [])), Some((0, [])), Some((1, [((0, 0), (1, 0))])), Some((1, [((0, 0), (1, 0))]))], start_tags: [0], code_blocks_n: 4 }
 fn count( lines :  Int, words :  Int, chars :  Int, lexbuf : Lexbuf ) ->  (Int, Int, Int)  {
- match __mbtlex_engine_count.run(lexbuf) {
- (0, __mbtlex_captures) => {
-  count(lines + 1, words, chars + 1, lexbuf) 
- }
- (1, __mbtlex_captures) => {
- let (_start_pos_of_word, _end_pos_of_word) = __mbtlex_captures[0]
- let word: String = lexbuf.substring(_start_pos_of_word, _end_pos_of_word)
- 
- 
-       let new_chars = chars + word.length()
-       count(lines, words + 1, new_chars, lexbuf)
-     
- }
- (2, __mbtlex_captures) => {
-  count(lines, words, chars + 1, lexbuf) 
- }
- (3, __mbtlex_captures) => {
-  (lines, words, chars) 
- }
- _ => abort("lex: fail to match")
- }
- }
+  match __mbtlex_engine_count.run(lexbuf) {
+    (0, __mbtlex_captures) => {
+ count(lines + 1, words, chars + 1, lexbuf) 
+    }
+    (1, __mbtlex_captures) => {
+  let (_start_pos_of_word, _end_pos_of_word) = __mbtlex_captures[0]
+  let word: String = lexbuf.substring(_start_pos_of_word, _end_pos_of_word)
+  
+
+      let new_chars = chars + word.length()
+      count(lines, words + 1, new_chars, lexbuf)
+    
+    }
+    (2, __mbtlex_captures) => {
+ count(lines, words, chars + 1, lexbuf) 
+    }
+    (3, __mbtlex_captures) => {
+ (lines, words, chars) 
+    }
+    _ => abort("lex: fail to match")
+  }
+}
 
 


### PR DESCRIPTION
This PR remove fix_indent in favor of manual generate indentation. The fix_indent is error-prone which block #26 to land.