### PR TITLE
Feat/longest match

### DIFF
--- a/boot/snapshot/moonlex.js
+++ b/boot/snapshot/moonlex.js
@@ -23374,13 +23374,12 @@ function moonbitlang$ulex$lib$codegen$$codegen_rule_inner(rule, code_unit, defau
         const _pattern_id = _x._0;
         const _captures = _x._1;
         const _tmp$4 = moonbitlang$core$builtin$$Show$to_string$6$(_pattern_id);
-        const _tmp$5 = moonbitlang$core$builtin$$Show$to_string$6$(_pattern_id);
         const _p$2 = rule.lexee;
-        moonbitlang$core$builtin$$Logger$write_string$36$(out, `      if _match_pattern >= ${_tmp$4} {\n        _match_pattern = ${_tmp$5}\n        _match_end = ${_p$2}.curr_pos()\n`);
+        moonbitlang$core$builtin$$Logger$write_string$36$(out, `      _match_pattern = ${_tmp$4}\n      _match_end = ${_p$2}.curr_pos()\n`);
         const _len$3 = _captures.length;
-        let _tmp$6 = 0;
+        let _tmp$5 = 0;
         while (true) {
-          const _i$2 = _tmp$6;
+          const _i$2 = _tmp$5;
           if (_i$2 < _len$3) {
             const capture = _captures[_i$2];
             const _begin = capture._0;
@@ -23388,9 +23387,9 @@ function moonbitlang$ulex$lib$codegen$$codegen_rule_inner(rule, code_unit, defau
             if (_begin.$tag === 0) {
               const _Dynamic_dfa = _begin;
               const _begin_tag_var = _Dynamic_dfa._0;
-              const _tmp$7 = moonbitlang$core$builtin$$Show$to_string$6$(_i$2);
+              const _tmp$6 = moonbitlang$core$builtin$$Show$to_string$6$(_i$2);
               const _p$3 = moonbitlang$ulex$lib$codegen$$codegen_rule_inner$46$gen_tag_var$124$39(_begin_tag_var);
-              moonbitlang$core$builtin$$Logger$write_string$36$(out, `        _capture_${_tmp$7}_start = ${_p$3}\n`);
+              moonbitlang$core$builtin$$Logger$write_string$36$(out, `      _capture_${_tmp$6}_start = ${_p$3}\n`);
             } else {
               const _Static_dfa = _begin;
               const _x$2 = _Static_dfa._0;
@@ -23398,26 +23397,26 @@ function moonbitlang$ulex$lib$codegen$$codegen_rule_inner(rule, code_unit, defau
                 const _RelativeToStart = _x$2;
                 const _offset = _RelativeToStart._0;
                 if (_offset === 0) {
-                  moonbitlang$core$builtin$$Logger$write_string$36$(out, `        _capture_${moonbitlang$core$builtin$$Show$to_string$6$(_i$2)}_start = _match_start\n`);
+                  moonbitlang$core$builtin$$Logger$write_string$36$(out, `      _capture_${moonbitlang$core$builtin$$Show$to_string$6$(_i$2)}_start = _match_start\n`);
                 } else {
-                  moonbitlang$core$builtin$$Logger$write_string$36$(out, `        _capture_${moonbitlang$core$builtin$$Show$to_string$6$(_i$2)}_start = _match_start + ${moonbitlang$core$builtin$$Show$to_string$6$(_offset)}\n`);
+                  moonbitlang$core$builtin$$Logger$write_string$36$(out, `      _capture_${moonbitlang$core$builtin$$Show$to_string$6$(_i$2)}_start = _match_start + ${moonbitlang$core$builtin$$Show$to_string$6$(_offset)}\n`);
                 }
               } else {
                 const _RelativeToEnd = _x$2;
                 const _offset = _RelativeToEnd._0;
                 if (_offset === 0) {
-                  moonbitlang$core$builtin$$Logger$write_string$36$(out, `        _capture_${moonbitlang$core$builtin$$Show$to_string$6$(_i$2)}_start = _match_end\n`);
+                  moonbitlang$core$builtin$$Logger$write_string$36$(out, `      _capture_${moonbitlang$core$builtin$$Show$to_string$6$(_i$2)}_start = _match_end\n`);
                 } else {
-                  moonbitlang$core$builtin$$Logger$write_string$36$(out, `        _capture_${moonbitlang$core$builtin$$Show$to_string$6$(_i$2)}_start = _match_end + ${moonbitlang$core$builtin$$Show$to_string$6$(_offset)}\n`);
+                  moonbitlang$core$builtin$$Logger$write_string$36$(out, `      _capture_${moonbitlang$core$builtin$$Show$to_string$6$(_i$2)}_start = _match_end + ${moonbitlang$core$builtin$$Show$to_string$6$(_offset)}\n`);
                 }
               }
             }
             if (_end.$tag === 0) {
               const _Dynamic_dfa = _end;
               const _end_tag_var = _Dynamic_dfa._0;
-              const _tmp$7 = moonbitlang$core$builtin$$Show$to_string$6$(_i$2);
+              const _tmp$6 = moonbitlang$core$builtin$$Show$to_string$6$(_i$2);
               const _p$3 = moonbitlang$ulex$lib$codegen$$codegen_rule_inner$46$gen_tag_var$124$39(_end_tag_var);
-              moonbitlang$core$builtin$$Logger$write_string$36$(out, `        _capture_${_tmp$7}_end = ${_p$3}\n`);
+              moonbitlang$core$builtin$$Logger$write_string$36$(out, `      _capture_${_tmp$6}_end = ${_p$3}\n`);
             } else {
               const _Static_dfa = _end;
               const _x$2 = _Static_dfa._0;
@@ -23425,27 +23424,27 @@ function moonbitlang$ulex$lib$codegen$$codegen_rule_inner(rule, code_unit, defau
                 const _RelativeToStart = _x$2;
                 const _offset = _RelativeToStart._0;
                 if (_offset === 0) {
-                  moonbitlang$core$builtin$$Logger$write_string$36$(out, `        _capture_${moonbitlang$core$builtin$$Show$to_string$6$(_i$2)}_end = _match_start\n`);
+                  moonbitlang$core$builtin$$Logger$write_string$36$(out, `      _capture_${moonbitlang$core$builtin$$Show$to_string$6$(_i$2)}_end = _match_start\n`);
                 } else {
-                  moonbitlang$core$builtin$$Logger$write_string$36$(out, `        _capture_${moonbitlang$core$builtin$$Show$to_string$6$(_i$2)}_end = _match_start + ${moonbitlang$core$builtin$$Show$to_string$6$(_offset)}\n`);
+                  moonbitlang$core$builtin$$Logger$write_string$36$(out, `      _capture_${moonbitlang$core$builtin$$Show$to_string$6$(_i$2)}_end = _match_start + ${moonbitlang$core$builtin$$Show$to_string$6$(_offset)}\n`);
                 }
               } else {
                 const _RelativeToEnd = _x$2;
                 const _offset = _RelativeToEnd._0;
                 if (_offset === 0) {
-                  moonbitlang$core$builtin$$Logger$write_string$36$(out, `        _capture_${moonbitlang$core$builtin$$Show$to_string$6$(_i$2)}_end = _match_end\n`);
+                  moonbitlang$core$builtin$$Logger$write_string$36$(out, `      _capture_${moonbitlang$core$builtin$$Show$to_string$6$(_i$2)}_end = _match_end\n`);
                 } else {
-                  moonbitlang$core$builtin$$Logger$write_string$36$(out, `        _capture_${moonbitlang$core$builtin$$Show$to_string$6$(_i$2)}_end = _match_end + ${moonbitlang$core$builtin$$Show$to_string$6$(_offset)}\n`);
+                  moonbitlang$core$builtin$$Logger$write_string$36$(out, `      _capture_${moonbitlang$core$builtin$$Show$to_string$6$(_i$2)}_end = _match_end + ${moonbitlang$core$builtin$$Show$to_string$6$(_offset)}\n`);
                 }
               }
             }
-            _tmp$6 = _i$2 + 1 | 0;
+            _tmp$5 = _i$2 + 1 | 0;
             continue;
           } else {
             break;
           }
         }
-        moonbitlang$core$builtin$$Logger$write_string$36$(out, "      }\n");
+        moonbitlang$core$builtin$$Logger$write_string$36$(out, "");
       }
       const grouped_trans = moonbitlang$ulex$lib$codegen$$group_trans(trans);
       if (grouped_trans.length === 0) {

--- a/src/lib/codegen/codeblock_parser/codeblock_parser.mbt
+++ b/src/lib/codegen/codeblock_parser/codeblock_parser.mbt
@@ -29,10 +29,8 @@ fn[T : @lexbuf.IStringLexbuf] scan_codeblock_rbrace(subst : Array[SubstItem], le
   let mut _tag_2 = -1
   loop 0 {
     0 => {
-      if _match_pattern >= 5 {
-        _match_pattern = 5
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 5
+      _match_end = lexbuf.curr_pos()
       continue match lexbuf.next_as_int() {
         0..=35 => 1
         36 => 2
@@ -45,17 +43,13 @@ fn[T : @lexbuf.IStringLexbuf] scan_codeblock_rbrace(subst : Array[SubstItem], le
       }
     }
     1 => {
-      if _match_pattern >= 4 {
-        _match_pattern = 4
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 4
+      _match_end = lexbuf.curr_pos()
       break
     }
     2 => {
-      if _match_pattern >= 4 {
-        _match_pattern = 4
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 4
+      _match_end = lexbuf.curr_pos()
       continue match lexbuf.next_as_int() {
         65..=90 => 5
         95 => 5
@@ -68,26 +62,20 @@ fn[T : @lexbuf.IStringLexbuf] scan_codeblock_rbrace(subst : Array[SubstItem], le
       }
     }
     3 => {
-      if _match_pattern >= 0 {
-        _match_pattern = 0
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 0
+      _match_end = lexbuf.curr_pos()
       break
     }
     4 => {
-      if _match_pattern >= 1 {
-        _match_pattern = 1
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 1
+      _match_end = lexbuf.curr_pos()
       break
     }
     5 => {
-      if _match_pattern >= 3 {
-        _match_pattern = 3
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start + 1
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 3
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start + 1
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         48..=57 => 5
         65..=90 => 5
@@ -97,12 +85,10 @@ fn[T : @lexbuf.IStringLexbuf] scan_codeblock_rbrace(subst : Array[SubstItem], le
       }
     }
     6 => {
-      if _match_pattern >= 3 {
-        _match_pattern = 3
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start + 1
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 3
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start + 1
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         48..=57 => 5
         65..=90 => 5
@@ -114,12 +100,10 @@ fn[T : @lexbuf.IStringLexbuf] scan_codeblock_rbrace(subst : Array[SubstItem], le
       }
     }
     7 => {
-      if _match_pattern >= 3 {
-        _match_pattern = 3
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start + 1
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 3
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start + 1
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         48..=57 => 5
         65..=90 => 5
@@ -131,12 +115,10 @@ fn[T : @lexbuf.IStringLexbuf] scan_codeblock_rbrace(subst : Array[SubstItem], le
       }
     }
     8 => {
-      if _match_pattern >= 3 {
-        _match_pattern = 3
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start + 1
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 3
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start + 1
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         48..=57 => 5
         65..=90 => 5
@@ -148,12 +130,10 @@ fn[T : @lexbuf.IStringLexbuf] scan_codeblock_rbrace(subst : Array[SubstItem], le
       }
     }
     9 => {
-      if _match_pattern >= 3 {
-        _match_pattern = 3
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start + 1
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 3
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start + 1
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         48..=57 => 5
         65..=90 => 5
@@ -164,12 +144,10 @@ fn[T : @lexbuf.IStringLexbuf] scan_codeblock_rbrace(subst : Array[SubstItem], le
       }
     }
     10 => {
-      if _match_pattern >= 3 {
-        _match_pattern = 3
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start + 1
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 3
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start + 1
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         48..=57 => 5
         65..=90 => 5
@@ -181,12 +159,10 @@ fn[T : @lexbuf.IStringLexbuf] scan_codeblock_rbrace(subst : Array[SubstItem], le
       }
     }
     11 => {
-      if _match_pattern >= 3 {
-        _match_pattern = 3
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start + 1
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 3
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start + 1
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         48..=57 => 5
         65..=90 => 5
@@ -198,12 +174,10 @@ fn[T : @lexbuf.IStringLexbuf] scan_codeblock_rbrace(subst : Array[SubstItem], le
       }
     }
     12 => {
-      if _match_pattern >= 3 {
-        _match_pattern = 3
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start + 1
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 3
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start + 1
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         48..=57 => 5
         65..=90 => 5
@@ -215,12 +189,10 @@ fn[T : @lexbuf.IStringLexbuf] scan_codeblock_rbrace(subst : Array[SubstItem], le
       }
     }
     13 => {
-      if _match_pattern >= 3 {
-        _match_pattern = 3
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start + 1
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 3
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start + 1
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         48..=57 => 5
         65..=90 => 5
@@ -232,12 +204,10 @@ fn[T : @lexbuf.IStringLexbuf] scan_codeblock_rbrace(subst : Array[SubstItem], le
       }
     }
     14 => {
-      if _match_pattern >= 3 {
-        _match_pattern = 3
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start + 1
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 3
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start + 1
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         48..=57 => 5
         65..=90 => 5
@@ -250,12 +220,10 @@ fn[T : @lexbuf.IStringLexbuf] scan_codeblock_rbrace(subst : Array[SubstItem], le
     }
     15 => {
       _tag_0 = lexbuf.curr_pos()
-      if _match_pattern >= 3 {
-        _match_pattern = 3
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start + 1
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 3
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start + 1
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         40 => 16
         48..=57 => 5
@@ -298,14 +266,12 @@ fn[T : @lexbuf.IStringLexbuf] scan_codeblock_rbrace(subst : Array[SubstItem], le
       }
     }
     19 => {
-      if _match_pattern >= 2 {
-        _match_pattern = 2
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start + 1
-        _capture_0_end = _tag_0
-        _capture_1_start = _tag_1
-        _capture_1_end = _tag_2
-      }
+      _match_pattern = 2
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start + 1
+      _capture_0_end = _tag_0
+      _capture_1_start = _tag_1
+      _capture_1_end = _tag_2
       break
     }
     _ => panic()

--- a/src/lib/codegen/codegen.mbt
+++ b/src/lib/codegen/codegen.mbt
@@ -191,9 +191,8 @@ pub fn codegen_rule_inner(
     }
     if dfa.end_nodes.get(state_num) is Some((pattern_id, captures)) {
       out.write_string(
-        $|      if _match_pattern >= \{pattern_id} {
-        $|        _match_pattern = \{pattern_id}
-        $|        _match_end = \{rule.lexee}.curr_pos()
+        $|      _match_pattern = \{pattern_id}
+        $|      _match_end = \{rule.lexee}.curr_pos()
         $|
         ,
       )
@@ -202,52 +201,51 @@ pub fn codegen_rule_inner(
         match begin {
           Dynamic_dfa(begin_tag_var) =>
             out.write_string(
-              "        _capture_\{index}_start = \{gen_tag_var(begin_tag_var)}\n",
+              "      _capture_\{index}_start = \{gen_tag_var(begin_tag_var)}\n",
             )
           Static_dfa(RelativeToStart(offset)) =>
             if offset == 0 {
               out.write_string(
-                "        _capture_\{index}_start = _match_start\n",
+                "      _capture_\{index}_start = _match_start\n",
               )
             } else {
               out.write_string(
-                "        _capture_\{index}_start = _match_start + \{offset}\n",
+                "      _capture_\{index}_start = _match_start + \{offset}\n",
               )
             }
           Static_dfa(RelativeToEnd(offset)) =>
             if offset == 0 {
-              out.write_string("        _capture_\{index}_start = _match_end\n")
+              out.write_string("      _capture_\{index}_start = _match_end\n")
             } else {
               out.write_string(
-                "        _capture_\{index}_start = _match_end + \{offset}\n",
+                "      _capture_\{index}_start = _match_end + \{offset}\n",
               )
             }
         }
         match end {
           Dynamic_dfa(end_tag_var) =>
             out.write_string(
-              "        _capture_\{index}_end = \{gen_tag_var(end_tag_var)}\n",
+              "      _capture_\{index}_end = \{gen_tag_var(end_tag_var)}\n",
             )
           Static_dfa(RelativeToStart(offset)) =>
             if offset == 0 {
-              out.write_string("        _capture_\{index}_end = _match_start\n")
+              out.write_string("      _capture_\{index}_end = _match_start\n")
             } else {
               out.write_string(
-                "        _capture_\{index}_end = _match_start + \{offset}\n",
+                "      _capture_\{index}_end = _match_start + \{offset}\n",
               )
             }
           Static_dfa(RelativeToEnd(offset)) =>
             if offset == 0 {
-              out.write_string("        _capture_\{index}_end = _match_end\n")
+              out.write_string("      _capture_\{index}_end = _match_end\n")
             } else {
               out.write_string(
-                "        _capture_\{index}_end = _match_end + \{offset}\n",
+                "      _capture_\{index}_end = _match_end + \{offset}\n",
               )
             }
         }
       }
       out.write_string(
-        $|      }
         $|
         ,
       )

--- a/src/lib/new_frontend/lexer/lexer.mbt
+++ b/src/lib/new_frontend/lexer/lexer.mbt
@@ -69,28 +69,22 @@ fn interp_handle(lexbuf : Lexbuf, env~ : LexEnv) -> Int  {
       }
     }
     1 => {
-      if _match_pattern >= 1 {
-        _match_pattern = 1
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 1
+      _match_end = lexbuf.curr_pos()
       break
     }
     2 => {
-      if _match_pattern >= 4 {
-        _match_pattern = 4
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 4
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       break
     }
     3 => {
-      if _match_pattern >= 4 {
-        _match_pattern = 4
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 4
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         9 => 22
         11..=12 => 22
@@ -105,26 +99,20 @@ fn interp_handle(lexbuf : Lexbuf, env~ : LexEnv) -> Int  {
       }
     }
     4 => {
-      if _match_pattern >= 2 {
-        _match_pattern = 2
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 2
+      _match_end = lexbuf.curr_pos()
       break
     }
     5 => {
-      if _match_pattern >= 5 {
-        _match_pattern = 5
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 5
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       break
     }
     6 => {
-      if _match_pattern >= 0 {
-        _match_pattern = 0
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 0
+      _match_end = lexbuf.curr_pos()
       break
     }
     7 => {
@@ -392,47 +380,37 @@ fn normal(lexbuf : Lexbuf, env~ : LexEnv, end_with_newline~ : Bool, allow_interp
       }
     }
     1 => {
-      if _match_pattern >= 11 {
-        _match_pattern = 11
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 11
+      _match_end = lexbuf.curr_pos()
       break
     }
     2 => {
-      if _match_pattern >= 13 {
-        _match_pattern = 13
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 13
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       break
     }
     3 => {
-      if _match_pattern >= 13 {
-        _match_pattern = 13
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 13
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         10 => 10
         _ => break
       }
     }
     4 => {
-      if _match_pattern >= 0 {
-        _match_pattern = 0
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 0
+      _match_end = lexbuf.curr_pos()
       break
     }
     5 => {
-      if _match_pattern >= 13 {
-        _match_pattern = 13
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 13
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         0..=31 => 11
         32 => 12
@@ -489,37 +467,29 @@ fn normal(lexbuf : Lexbuf, env~ : LexEnv, end_with_newline~ : Bool, allow_interp
       }
     }
     10 => {
-      if _match_pattern >= 12 {
-        _match_pattern = 12
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 12
+      _match_end = lexbuf.curr_pos()
       break
     }
     11 => {
-      if _match_pattern >= 10 {
-        _match_pattern = 10
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 10
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       break
     }
     12 => {
-      if _match_pattern >= 1 {
-        _match_pattern = 1
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 2
-      }
+      _match_pattern = 1
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 2
       break
     }
     13 => {
-      if _match_pattern >= 10 {
-        _match_pattern = 10
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 10
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         0..=47 => 28
         48..=51 => 29
@@ -532,12 +502,10 @@ fn normal(lexbuf : Lexbuf, env~ : LexEnv, end_with_newline~ : Bool, allow_interp
       }
     }
     14 => {
-      if _match_pattern >= 10 {
-        _match_pattern = 10
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 10
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         48..=57 => 26
         65..=70 => 26
@@ -547,12 +515,10 @@ fn normal(lexbuf : Lexbuf, env~ : LexEnv, end_with_newline~ : Bool, allow_interp
       }
     }
     15 => {
-      if _match_pattern >= 10 {
-        _match_pattern = 10
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 10
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         0..=47 => 34
         48..=57 => 35
@@ -569,12 +535,10 @@ fn normal(lexbuf : Lexbuf, env~ : LexEnv, end_with_newline~ : Bool, allow_interp
       }
     }
     16 => {
-      if _match_pattern >= 9 {
-        _match_pattern = 9
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 9
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         9 => 16
         11..=12 => 16
@@ -826,12 +790,10 @@ fn normal(lexbuf : Lexbuf, env~ : LexEnv, end_with_newline~ : Bool, allow_interp
       }
     }
     46 => {
-      if _match_pattern >= 8 {
-        _match_pattern = 8
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 8
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       break
     }
     47 => {
@@ -913,12 +875,10 @@ fn normal(lexbuf : Lexbuf, env~ : LexEnv, end_with_newline~ : Bool, allow_interp
       }
     }
     58 => {
-      if _match_pattern >= 3 {
-        _match_pattern = 3
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 3
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       break
     }
     59 => {
@@ -946,21 +906,17 @@ fn normal(lexbuf : Lexbuf, env~ : LexEnv, end_with_newline~ : Bool, allow_interp
       }
     }
     63 => {
-      if _match_pattern >= 2 {
-        _match_pattern = 2
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 4
-      }
+      _match_pattern = 2
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 4
       break
     }
     64 => {
-      if _match_pattern >= 7 {
-        _match_pattern = 7
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 7
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       break
     }
     65 => {
@@ -972,12 +928,10 @@ fn normal(lexbuf : Lexbuf, env~ : LexEnv, end_with_newline~ : Bool, allow_interp
       }
     }
     66 => {
-      if _match_pattern >= 5 {
-        _match_pattern = 5
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 5
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       break
     }
     67 => {
@@ -1005,21 +959,17 @@ fn normal(lexbuf : Lexbuf, env~ : LexEnv, end_with_newline~ : Bool, allow_interp
       }
     }
     71 => {
-      if _match_pattern >= 4 {
-        _match_pattern = 4
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 5
-      }
+      _match_pattern = 4
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 5
       break
     }
     72 => {
-      if _match_pattern >= 6 {
-        _match_pattern = 6
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 6
-      }
+      _match_pattern = 6
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 6
       break
     }
     _ => panic()
@@ -1231,19 +1181,15 @@ fn invalid_byte(lexbuf : Lexbuf, env~ : LexEnv, start~ : Int) -> Unit  {
       }
     }
     1 => {
-      if _match_pattern >= 0 {
-        _match_pattern = 0
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 0
+      _match_end = lexbuf.curr_pos()
       break
     }
     2 => {
-      if _match_pattern >= 1 {
-        _match_pattern = 1
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 1
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       break
     }
     3 => {
@@ -1284,10 +1230,8 @@ fn invalid_byte(lexbuf : Lexbuf, env~ : LexEnv, start~ : Int) -> Unit  {
       }
     }
     9 => {
-      if _match_pattern >= 2 {
-        _match_pattern = 2
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 2
+      _match_end = lexbuf.curr_pos()
       break
     }
     _ => panic()
@@ -1408,26 +1352,20 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     1 => {
-      if _match_pattern >= 66 {
-        _match_pattern = 66
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 66
+      _match_end = lexbuf.curr_pos()
       break
     }
     2 => {
-      if _match_pattern >= 70 {
-        _match_pattern = 70
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 70
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       break
     }
     3 => {
-      if _match_pattern >= 1 {
-        _match_pattern = 1
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 1
+      _match_end = lexbuf.curr_pos()
       continue match lexbuf.next_as_int() {
         9 => 3
         11..=12 => 3
@@ -1441,46 +1379,36 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     4 => {
-      if _match_pattern >= 0 {
-        _match_pattern = 0
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 0
+      _match_end = lexbuf.curr_pos()
       break
     }
     5 => {
-      if _match_pattern >= 0 {
-        _match_pattern = 0
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 0
+      _match_end = lexbuf.curr_pos()
       continue match lexbuf.next_as_int() {
         10 => 4
         _ => break
       }
     }
     6 => {
-      if _match_pattern >= 62 {
-        _match_pattern = 62
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 62
+      _match_end = lexbuf.curr_pos()
       continue match lexbuf.next_as_int() {
         61 => 86
         _ => break
       }
     }
     7 => {
-      if _match_pattern >= 11 {
-        _match_pattern = 11
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 11
+      _match_end = lexbuf.curr_pos()
       break
     }
     8 => {
-      if _match_pattern >= 70 {
-        _match_pattern = 70
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 70
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         65..=90 => 114
         97..=122 => 114
@@ -1489,44 +1417,36 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     9 => {
-      if _match_pattern >= 70 {
-        _match_pattern = 70
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 70
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         124 => 116
         _ => break
       }
     }
     10 => {
-      if _match_pattern >= 30 {
-        _match_pattern = 30
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 30
+      _match_end = lexbuf.curr_pos()
       continue match lexbuf.next_as_int() {
         61 => 111
         _ => break
       }
     }
     11 => {
-      if _match_pattern >= 23 {
-        _match_pattern = 23
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 23
+      _match_end = lexbuf.curr_pos()
       continue match lexbuf.next_as_int() {
         38 => 112
         _ => break
       }
     }
     12 => {
-      if _match_pattern >= 70 {
-        _match_pattern = 70
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 70
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         0..=9 => 119
         11..=12 => 119
@@ -1542,51 +1462,39 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     13 => {
-      if _match_pattern >= 25 {
-        _match_pattern = 25
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 25
+      _match_end = lexbuf.curr_pos()
       break
     }
     14 => {
-      if _match_pattern >= 26 {
-        _match_pattern = 26
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 26
+      _match_end = lexbuf.curr_pos()
       break
     }
     15 => {
-      if _match_pattern >= 28 {
-        _match_pattern = 28
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 28
+      _match_end = lexbuf.curr_pos()
       continue match lexbuf.next_as_int() {
         61 => 111
         _ => break
       }
     }
     16 => {
-      if _match_pattern >= 58 {
-        _match_pattern = 58
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 58
+      _match_end = lexbuf.curr_pos()
       continue match lexbuf.next_as_int() {
         61 => 111
         _ => break
       }
     }
     17 => {
-      if _match_pattern >= 31 {
-        _match_pattern = 31
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 31
+      _match_end = lexbuf.curr_pos()
       break
     }
     18 => {
-      if _match_pattern >= 59 {
-        _match_pattern = 59
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 59
+      _match_end = lexbuf.curr_pos()
       continue match lexbuf.next_as_int() {
         61 => 111
         62 => 126
@@ -1594,12 +1502,10 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     19 => {
-      if _match_pattern >= 70 {
-        _match_pattern = 70
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 70
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         40 => 94
         46 => 95
@@ -1624,10 +1530,8 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     20 => {
-      if _match_pattern >= 29 {
-        _match_pattern = 29
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 29
+      _match_end = lexbuf.curr_pos()
       continue match lexbuf.next_as_int() {
         47 => 125
         61 => 111
@@ -1635,12 +1539,10 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     21 => {
-      if _match_pattern >= 65 {
-        _match_pattern = 65
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 65
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         46 => 80
         48..=57 => 22
@@ -1658,12 +1560,10 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     22 => {
-      if _match_pattern >= 65 {
-        _match_pattern = 65
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 65
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         46 => 80
         48..=57 => 22
@@ -1675,27 +1575,21 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     23 => {
-      if _match_pattern >= 41 {
-        _match_pattern = 41
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 41
+      _match_end = lexbuf.curr_pos()
       continue match lexbuf.next_as_int() {
         58 => 93
         _ => break
       }
     }
     24 => {
-      if _match_pattern >= 42 {
-        _match_pattern = 42
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 42
+      _match_end = lexbuf.curr_pos()
       break
     }
     25 => {
-      if _match_pattern >= 50 {
-        _match_pattern = 50
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 50
+      _match_end = lexbuf.curr_pos()
       continue match lexbuf.next_as_int() {
         60 => 91
         61 => 92
@@ -1703,10 +1597,8 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     26 => {
-      if _match_pattern >= 44 {
-        _match_pattern = 44
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 44
+      _match_end = lexbuf.curr_pos()
       continue match lexbuf.next_as_int() {
         61 => 127
         62 => 128
@@ -1714,10 +1606,8 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     27 => {
-      if _match_pattern >= 48 {
-        _match_pattern = 48
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 48
+      _match_end = lexbuf.curr_pos()
       continue match lexbuf.next_as_int() {
         61 => 89
         62 => 90
@@ -1725,19 +1615,15 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     28 => {
-      if _match_pattern >= 60 {
-        _match_pattern = 60
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 60
+      _match_end = lexbuf.curr_pos()
       break
     }
     29 => {
-      if _match_pattern >= 70 {
-        _match_pattern = 70
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 70
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         65..=90 => 113
         95 => 113
@@ -1746,12 +1632,10 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     30 => {
-      if _match_pattern >= 67 {
-        _match_pattern = 67
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 67
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         48..=57 => 30
         65..=90 => 30
@@ -1774,33 +1658,25 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     31 => {
-      if _match_pattern >= 51 {
-        _match_pattern = 51
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 51
+      _match_end = lexbuf.curr_pos()
       break
     }
     32 => {
-      if _match_pattern >= 52 {
-        _match_pattern = 52
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 52
+      _match_end = lexbuf.curr_pos()
       break
     }
     33 => {
-      if _match_pattern >= 24 {
-        _match_pattern = 24
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 24
+      _match_end = lexbuf.curr_pos()
       break
     }
     34 => {
-      if _match_pattern >= 69 {
-        _match_pattern = 69
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 69
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         48..=57 => 34
         65..=90 => 34
@@ -1824,12 +1700,10 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     35 => {
-      if _match_pattern >= 69 {
-        _match_pattern = 69
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 69
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         34 => 117
         39 => 118
@@ -1855,17 +1729,13 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     36 => {
-      if _match_pattern >= 53 {
-        _match_pattern = 53
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 53
+      _match_end = lexbuf.curr_pos()
       break
     }
     37 => {
-      if _match_pattern >= 57 {
-        _match_pattern = 57
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 57
+      _match_end = lexbuf.curr_pos()
       continue match lexbuf.next_as_int() {
         62 => 87
         124 => 88
@@ -1873,10 +1743,8 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     38 => {
-      if _match_pattern >= 54 {
-        _match_pattern = 54
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 54
+      _match_end = lexbuf.curr_pos()
       break
     }
     39 => {
@@ -2030,12 +1898,10 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     57 => {
-      if _match_pattern >= 68 {
-        _match_pattern = 68
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end + -1
-      }
+      _match_pattern = 68
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end + -1
       break
     }
     58 => {
@@ -2191,12 +2057,10 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     80 => {
-      if _match_pattern >= 64 {
-        _match_pattern = 64
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 64
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         46 => 148
         48..=57 => 149
@@ -2213,12 +2077,10 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     82 => {
-      if _match_pattern >= 65 {
-        _match_pattern = 65
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 65
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         46 => 151
         _ => break
@@ -2231,12 +2093,10 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     84 => {
-      if _match_pattern >= 65 {
-        _match_pattern = 65
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 65
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         46 => 151
         76 => 82
@@ -2252,73 +2112,53 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     86 => {
-      if _match_pattern >= 61 {
-        _match_pattern = 61
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 61
+      _match_end = lexbuf.curr_pos()
       break
     }
     87 => {
-      if _match_pattern >= 55 {
-        _match_pattern = 55
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 55
+      _match_end = lexbuf.curr_pos()
       break
     }
     88 => {
-      if _match_pattern >= 56 {
-        _match_pattern = 56
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 56
+      _match_end = lexbuf.curr_pos()
       break
     }
     89 => {
-      if _match_pattern >= 46 {
-        _match_pattern = 46
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 46
+      _match_end = lexbuf.curr_pos()
       break
     }
     90 => {
-      if _match_pattern >= 47 {
-        _match_pattern = 47
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 47
+      _match_end = lexbuf.curr_pos()
       break
     }
     91 => {
-      if _match_pattern >= 49 {
-        _match_pattern = 49
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 49
+      _match_end = lexbuf.curr_pos()
       break
     }
     92 => {
-      if _match_pattern >= 45 {
-        _match_pattern = 45
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 45
+      _match_end = lexbuf.curr_pos()
       break
     }
     93 => {
-      if _match_pattern >= 40 {
-        _match_pattern = 40
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 40
+      _match_end = lexbuf.curr_pos()
       break
     }
     94 => {
-      if _match_pattern >= 32 {
-        _match_pattern = 32
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 32
+      _match_end = lexbuf.curr_pos()
       break
     }
     95 => {
-      if _match_pattern >= 37 {
-        _match_pattern = 37
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 37
+      _match_end = lexbuf.curr_pos()
       continue match lexbuf.next_as_int() {
         46 => 171
         60 => 172
@@ -2327,26 +2167,22 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     96 => {
-      if _match_pattern >= 33 {
-        _match_pattern = 33
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-        _capture_1_start = _match_start + 1
-        _capture_1_end = _match_end
-      }
+      _match_pattern = 33
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
+      _capture_1_start = _match_start + 1
+      _capture_1_end = _match_end
       continue match lexbuf.next_as_int() {
         48..=57 => 96
         _ => break
       }
     }
     97 => {
-      if _match_pattern >= 38 {
-        _match_pattern = 38
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start + 1
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 38
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start + 1
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         48..=57 => 97
         65..=90 => 97
@@ -2369,12 +2205,10 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     98 => {
-      if _match_pattern >= 39 {
-        _match_pattern = 39
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start + 1
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 39
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start + 1
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         48..=57 => 98
         65..=90 => 98
@@ -2479,30 +2313,24 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     111 => {
-      if _match_pattern >= 27 {
-        _match_pattern = 27
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 1
-        _capture_1_start = _match_start
-        _capture_1_end = _match_start + 2
-      }
+      _match_pattern = 27
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 1
+      _capture_1_start = _match_start
+      _capture_1_end = _match_start + 2
       break
     }
     112 => {
-      if _match_pattern >= 22 {
-        _match_pattern = 22
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 22
+      _match_end = lexbuf.curr_pos()
       break
     }
     113 => {
-      if _match_pattern >= 16 {
-        _match_pattern = 16
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start + 1
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 16
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start + 1
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         47 => 174
         48..=57 => 113
@@ -2513,12 +2341,10 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     114 => {
-      if _match_pattern >= 15 {
-        _match_pattern = 15
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start + 1
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 15
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start + 1
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         0..=9 => 114
         11..=12 => 114
@@ -2531,12 +2357,10 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     115 => {
-      if _match_pattern >= 14 {
-        _match_pattern = 14
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start + 2
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 14
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start + 2
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         0..=9 => 115
         11..=12 => 115
@@ -2549,26 +2373,20 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     116 => {
-      if _match_pattern >= 13 {
-        _match_pattern = 13
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 13
+      _match_end = lexbuf.curr_pos()
       break
     }
     117 => {
-      if _match_pattern >= 12 {
-        _match_pattern = 12
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 12
+      _match_end = lexbuf.curr_pos()
       break
     }
     118 => {
-      if _match_pattern >= 21 {
-        _match_pattern = 21
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 2
-      }
+      _match_pattern = 21
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 2
       continue match lexbuf.next_as_int() {
         0..=91 => 183
         92 => 184
@@ -2623,12 +2441,10 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     125 => {
-      if _match_pattern >= 4 {
-        _match_pattern = 4
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 4
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         0..=9 => 125
         11..=12 => 125
@@ -2641,24 +2457,18 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     126 => {
-      if _match_pattern >= 3 {
-        _match_pattern = 3
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 3
+      _match_end = lexbuf.curr_pos()
       break
     }
     127 => {
-      if _match_pattern >= 43 {
-        _match_pattern = 43
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 43
+      _match_end = lexbuf.curr_pos()
       break
     }
     128 => {
-      if _match_pattern >= 2 {
-        _match_pattern = 2
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 2
+      _match_end = lexbuf.curr_pos()
       break
     }
     129 => {
@@ -2788,21 +2598,17 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     148 => {
-      if _match_pattern >= 63 {
-        _match_pattern = 63
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end + -2
-      }
+      _match_pattern = 63
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end + -2
       break
     }
     149 => {
-      if _match_pattern >= 64 {
-        _match_pattern = 64
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 64
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         48..=57 => 149
         69 => 150
@@ -2826,12 +2632,10 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     152 => {
-      if _match_pattern >= 65 {
-        _match_pattern = 65
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 65
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         46 => 151
         48..=49 => 152
@@ -2843,12 +2647,10 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     153 => {
-      if _match_pattern >= 65 {
-        _match_pattern = 65
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 65
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         46 => 151
         48..=55 => 153
@@ -2860,12 +2662,10 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     154 => {
-      if _match_pattern >= 65 {
-        _match_pattern = 65
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 65
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         46 => 201
         48..=57 => 154
@@ -2985,24 +2785,18 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     171 => {
-      if _match_pattern >= 34 {
-        _match_pattern = 34
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 34
+      _match_end = lexbuf.curr_pos()
       break
     }
     172 => {
-      if _match_pattern >= 36 {
-        _match_pattern = 36
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 36
+      _match_end = lexbuf.curr_pos()
       break
     }
     173 => {
-      if _match_pattern >= 35 {
-        _match_pattern = 35
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 35
+      _match_end = lexbuf.curr_pos()
       break
     }
     174 => {
@@ -3112,12 +2906,10 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     189 => {
-      if _match_pattern >= 5 {
-        _match_pattern = 5
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 5
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       break
     }
     190 => {
@@ -3145,10 +2937,8 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     194 => {
-      if _match_pattern >= 1 {
-        _match_pattern = 1
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 1
+      _match_end = lexbuf.curr_pos()
       continue match lexbuf.next_as_int() {
         9 => 3
         11..=12 => 3
@@ -3206,12 +2996,10 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     200 => {
-      if _match_pattern >= 64 {
-        _match_pattern = 64
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 64
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         48..=57 => 200
         95 => 200
@@ -3219,12 +3007,10 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     201 => {
-      if _match_pattern >= 64 {
-        _match_pattern = 64
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 64
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         46 => 148
         48..=57 => 221
@@ -3261,12 +3047,10 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     206 => {
-      if _match_pattern >= 19 {
-        _match_pattern = 19
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start + 2
-        _capture_0_end = _match_start + 3
-      }
+      _match_pattern = 19
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start + 2
+      _capture_0_end = _match_start + 3
       break
     }
     207 => {
@@ -3276,12 +3060,10 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     208 => {
-      if _match_pattern >= 19 {
-        _match_pattern = 19
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start + 2
-        _capture_0_end = _match_start + 3
-      }
+      _match_pattern = 19
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start + 2
+      _capture_0_end = _match_start + 3
       continue match lexbuf.next_as_int() {
         39 => 222
         _ => break
@@ -3333,12 +3115,10 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     215 => {
-      if _match_pattern >= 6 {
-        _match_pattern = 6
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 4
-      }
+      _match_pattern = 6
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 4
       break
     }
     216 => {
@@ -3385,12 +3165,10 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     221 => {
-      if _match_pattern >= 64 {
-        _match_pattern = 64
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 64
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         48..=57 => 221
         65..=70 => 221
@@ -3402,12 +3180,10 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     222 => {
-      if _match_pattern >= 20 {
-        _match_pattern = 20
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start + 3
-        _capture_0_end = _match_start + 4
-      }
+      _match_pattern = 20
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start + 3
+      _capture_0_end = _match_start + 4
       break
     }
     223 => {
@@ -3463,14 +3239,12 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     231 => {
-      if _match_pattern >= 10 {
-        _match_pattern = 10
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start + 4
-        _capture_0_end = _match_end + -2
-        _capture_1_start = _match_start
-        _capture_1_end = _match_end
-      }
+      _match_pattern = 10
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start + 4
+      _capture_0_end = _match_end + -2
+      _capture_1_start = _match_start
+      _capture_1_end = _match_end
       break
     }
     232 => {
@@ -3488,12 +3262,10 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     234 => {
-      if _match_pattern >= 7 {
-        _match_pattern = 7
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 6
-      }
+      _match_pattern = 7
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 6
       break
     }
     235 => {
@@ -3503,12 +3275,10 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     236 => {
-      if _match_pattern >= 17 {
-        _match_pattern = 17
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start + 4
-        _capture_0_end = _match_start + 6
-      }
+      _match_pattern = 17
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start + 4
+      _capture_0_end = _match_start + 6
       break
     }
     237 => {
@@ -3518,30 +3288,24 @@ fn tokens(lexbuf : Lexbuf, env~ : LexEnv, preserve_comment~ : (Comment, Int, Int
       }
     }
     238 => {
-      if _match_pattern >= 8 {
-        _match_pattern = 8
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 7
-      }
+      _match_pattern = 8
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 7
       break
     }
     239 => {
-      if _match_pattern >= 18 {
-        _match_pattern = 18
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start + 4
-        _capture_0_end = _match_start + 7
-      }
+      _match_pattern = 18
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start + 4
+      _capture_0_end = _match_start + 7
       break
     }
     240 => {
-      if _match_pattern >= 9 {
-        _match_pattern = 9
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 8
-      }
+      _match_pattern = 9
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 8
       break
     }
     _ => panic()

--- a/src/lib/new_frontend/regex_parser/lexer.mbt
+++ b/src/lib/new_frontend/regex_parser/lexer.mbt
@@ -42,117 +42,87 @@ fn token(lexbuf : Lexbuf) -> (Token, Int, Int)  {
       }
     }
     1 => {
-      if _match_pattern >= 0 {
-        _match_pattern = 0
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 0
+      _match_end = lexbuf.curr_pos()
       break
     }
     2 => {
-      if _match_pattern >= 30 {
-        _match_pattern = 30
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 1
-      }
+      _match_pattern = 30
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 1
       break
     }
     3 => {
-      if _match_pattern >= 2 {
-        _match_pattern = 2
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 2
+      _match_end = lexbuf.curr_pos()
       break
     }
     4 => {
-      if _match_pattern >= 13 {
-        _match_pattern = 13
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 13
+      _match_end = lexbuf.curr_pos()
       break
     }
     5 => {
-      if _match_pattern >= 14 {
-        _match_pattern = 14
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 14
+      _match_end = lexbuf.curr_pos()
       break
     }
     6 => {
-      if _match_pattern >= 7 {
-        _match_pattern = 7
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 7
+      _match_end = lexbuf.curr_pos()
       break
     }
     7 => {
-      if _match_pattern >= 8 {
-        _match_pattern = 8
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 8
+      _match_end = lexbuf.curr_pos()
       break
     }
     8 => {
-      if _match_pattern >= 6 {
-        _match_pattern = 6
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 6
+      _match_end = lexbuf.curr_pos()
       break
     }
     9 => {
-      if _match_pattern >= 1 {
-        _match_pattern = 1
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 1
+      _match_end = lexbuf.curr_pos()
       break
     }
     10 => {
-      if _match_pattern >= 9 {
-        _match_pattern = 9
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 9
+      _match_end = lexbuf.curr_pos()
       break
     }
     11 => {
-      if _match_pattern >= 3 {
-        _match_pattern = 3
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 3
+      _match_end = lexbuf.curr_pos()
       break
     }
     12 => {
-      if _match_pattern >= 30 {
-        _match_pattern = 30
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 1
-      }
+      _match_pattern = 30
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 1
       continue match lexbuf.next_as_int() {
         92 => 17
         _ => break
       }
     }
     13 => {
-      if _match_pattern >= 4 {
-        _match_pattern = 4
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 4
+      _match_end = lexbuf.curr_pos()
       break
     }
     14 => {
-      if _match_pattern >= 5 {
-        _match_pattern = 5
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 5
+      _match_end = lexbuf.curr_pos()
       break
     }
     15 => {
-      if _match_pattern >= 30 {
-        _match_pattern = 30
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 1
-      }
+      _match_pattern = 30
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 1
       continue match lexbuf.next_as_int() {
         48 => 18
         49..=57 => 19
@@ -160,10 +130,8 @@ fn token(lexbuf : Lexbuf) -> (Token, Int, Int)  {
       }
     }
     16 => {
-      if _match_pattern >= 15 {
-        _match_pattern = 15
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 15
+      _match_end = lexbuf.curr_pos()
       break
     }
     17 => {
@@ -202,75 +170,59 @@ fn token(lexbuf : Lexbuf) -> (Token, Int, Int)  {
       }
     }
     20 => {
-      if _match_pattern >= 22 {
-        _match_pattern = 22
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 3
-      }
+      _match_pattern = 22
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 3
       break
     }
     21 => {
-      if _match_pattern >= 17 {
-        _match_pattern = 17
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 3
-      }
+      _match_pattern = 17
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 3
       break
     }
     22 => {
-      if _match_pattern >= 18 {
-        _match_pattern = 18
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 3
-      }
+      _match_pattern = 18
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 3
       break
     }
     23 => {
-      if _match_pattern >= 25 {
-        _match_pattern = 25
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 3
-      }
+      _match_pattern = 25
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 3
       break
     }
     24 => {
-      if _match_pattern >= 24 {
-        _match_pattern = 24
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 3
-      }
+      _match_pattern = 24
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 3
       break
     }
     25 => {
-      if _match_pattern >= 21 {
-        _match_pattern = 21
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 3
-      }
+      _match_pattern = 21
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 3
       break
     }
     26 => {
-      if _match_pattern >= 26 {
-        _match_pattern = 26
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 3
-      }
+      _match_pattern = 26
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 3
       break
     }
     27 => {
-      if _match_pattern >= 19 {
-        _match_pattern = 19
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 3
-      }
+      _match_pattern = 19
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 3
       break
     }
     28 => {
@@ -280,21 +232,17 @@ fn token(lexbuf : Lexbuf) -> (Token, Int, Int)  {
       }
     }
     29 => {
-      if _match_pattern >= 20 {
-        _match_pattern = 20
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 3
-      }
+      _match_pattern = 20
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 3
       break
     }
     30 => {
-      if _match_pattern >= 23 {
-        _match_pattern = 23
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 3
-      }
+      _match_pattern = 23
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 3
       break
     }
     31 => {
@@ -307,12 +255,10 @@ fn token(lexbuf : Lexbuf) -> (Token, Int, Int)  {
       }
     }
     32 => {
-      if _match_pattern >= 27 {
-        _match_pattern = 27
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 3
-      }
+      _match_pattern = 27
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 3
       break
     }
     33 => {
@@ -325,12 +271,10 @@ fn token(lexbuf : Lexbuf) -> (Token, Int, Int)  {
       }
     }
     34 => {
-      if _match_pattern >= 12 {
-        _match_pattern = 12
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start + 1
-        _capture_0_end = _match_end + -1
-      }
+      _match_pattern = 12
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start + 1
+      _capture_0_end = _match_end + -1
       break
     }
     35 => {
@@ -350,12 +294,10 @@ fn token(lexbuf : Lexbuf) -> (Token, Int, Int)  {
       }
     }
     37 => {
-      if _match_pattern >= 16 {
-        _match_pattern = 16
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 4
-      }
+      _match_pattern = 16
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 4
       break
     }
     38 => {
@@ -372,12 +314,10 @@ fn token(lexbuf : Lexbuf) -> (Token, Int, Int)  {
       }
     }
     40 => {
-      if _match_pattern >= 11 {
-        _match_pattern = 11
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start + 1
-        _capture_0_end = _match_end + -2
-      }
+      _match_pattern = 11
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start + 1
+      _capture_0_end = _match_end + -2
       break
     }
     41 => {
@@ -398,14 +338,12 @@ fn token(lexbuf : Lexbuf) -> (Token, Int, Int)  {
       }
     }
     43 => {
-      if _match_pattern >= 10 {
-        _match_pattern = 10
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start + 1
-        _capture_0_end = _tag_0
-        _capture_1_start = _tag_1
-        _capture_1_end = _match_end + -1
-      }
+      _match_pattern = 10
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start + 1
+      _capture_0_end = _tag_0
+      _capture_1_start = _tag_1
+      _capture_1_end = _match_end + -1
       break
     }
     44 => {
@@ -417,25 +355,21 @@ fn token(lexbuf : Lexbuf) -> (Token, Int, Int)  {
       }
     }
     45 => {
-      if _match_pattern >= 28 {
-        _match_pattern = 28
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-        _capture_1_start = _match_start + 4
-        _capture_1_end = _match_end + -1
-      }
+      _match_pattern = 28
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
+      _capture_1_start = _match_start + 4
+      _capture_1_end = _match_end + -1
       break
     }
     46 => {
-      if _match_pattern >= 29 {
-        _match_pattern = 29
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 7
-        _capture_1_start = _match_start + 3
-        _capture_1_end = _match_start + 7
-      }
+      _match_pattern = 29
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 7
+      _capture_1_start = _match_start + 3
+      _capture_1_end = _match_start + 7
       break
     }
     _ => panic()

--- a/src/lib/parser/lexer.mbt
+++ b/src/lib/parser/lexer.mbt
@@ -51,17 +51,13 @@ fn[T : @lexbuf.IStringLexbuf] token(lexbuf : T) -> (Token, Int, Int)  {
       }
     }
     1 => {
-      if _match_pattern >= 2 {
-        _match_pattern = 2
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 2
+      _match_end = lexbuf.curr_pos()
       break
     }
     2 => {
-      if _match_pattern >= 0 {
-        _match_pattern = 0
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 0
+      _match_end = lexbuf.curr_pos()
       continue match lexbuf.next_as_int() {
         9..=10 => 2
         13 => 2
@@ -70,10 +66,8 @@ fn[T : @lexbuf.IStringLexbuf] token(lexbuf : T) -> (Token, Int, Int)  {
       }
     }
     3 => {
-      if _match_pattern >= 33 {
-        _match_pattern = 33
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 33
+      _match_end = lexbuf.curr_pos()
       break
     }
     4 => {
@@ -86,38 +80,28 @@ fn[T : @lexbuf.IStringLexbuf] token(lexbuf : T) -> (Token, Int, Int)  {
       }
     }
     5 => {
-      if _match_pattern >= 9 {
-        _match_pattern = 9
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 9
+      _match_end = lexbuf.curr_pos()
       break
     }
     6 => {
-      if _match_pattern >= 10 {
-        _match_pattern = 10
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 10
+      _match_end = lexbuf.curr_pos()
       break
     }
     7 => {
-      if _match_pattern >= 16 {
-        _match_pattern = 16
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 16
+      _match_end = lexbuf.curr_pos()
       break
     }
     8 => {
-      if _match_pattern >= 17 {
-        _match_pattern = 17
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 17
+      _match_end = lexbuf.curr_pos()
       break
     }
     9 => {
-      if _match_pattern >= 19 {
-        _match_pattern = 19
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 19
+      _match_end = lexbuf.curr_pos()
       break
     }
     10 => {
@@ -127,62 +111,46 @@ fn[T : @lexbuf.IStringLexbuf] token(lexbuf : T) -> (Token, Int, Int)  {
       }
     }
     11 => {
-      if _match_pattern >= 14 {
-        _match_pattern = 14
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 14
+      _match_end = lexbuf.curr_pos()
       break
     }
     12 => {
-      if _match_pattern >= 13 {
-        _match_pattern = 13
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 13
+      _match_end = lexbuf.curr_pos()
       continue match lexbuf.next_as_int() {
         62 => 27
         _ => break
       }
     }
     13 => {
-      if _match_pattern >= 18 {
-        _match_pattern = 18
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 18
+      _match_end = lexbuf.curr_pos()
       break
     }
     14 => {
-      if _match_pattern >= 11 {
-        _match_pattern = 11
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 11
+      _match_end = lexbuf.curr_pos()
       break
     }
     15 => {
-      if _match_pattern >= 21 {
-        _match_pattern = 21
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 21
+      _match_end = lexbuf.curr_pos()
       break
     }
     16 => {
-      if _match_pattern >= 12 {
-        _match_pattern = 12
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 12
+      _match_end = lexbuf.curr_pos()
       break
     }
     17 => {
-      if _match_pattern >= 20 {
-        _match_pattern = 20
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 20
+      _match_end = lexbuf.curr_pos()
       break
     }
     18 => {
-      if _match_pattern >= 6 {
-        _match_pattern = 6
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 6
+      _match_end = lexbuf.curr_pos()
       continue match lexbuf.next_as_int() {
         48..=57 => 19
         65..=90 => 19
@@ -192,12 +160,10 @@ fn[T : @lexbuf.IStringLexbuf] token(lexbuf : T) -> (Token, Int, Int)  {
       }
     }
     19 => {
-      if _match_pattern >= 34 {
-        _match_pattern = 34
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 34
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         48..=57 => 19
         65..=90 => 19
@@ -207,12 +173,10 @@ fn[T : @lexbuf.IStringLexbuf] token(lexbuf : T) -> (Token, Int, Int)  {
       }
     }
     20 => {
-      if _match_pattern >= 34 {
-        _match_pattern = 34
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 34
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         48..=57 => 19
         65..=90 => 19
@@ -223,12 +187,10 @@ fn[T : @lexbuf.IStringLexbuf] token(lexbuf : T) -> (Token, Int, Int)  {
       }
     }
     21 => {
-      if _match_pattern >= 34 {
-        _match_pattern = 34
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 34
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         48..=57 => 19
         65..=90 => 19
@@ -240,24 +202,18 @@ fn[T : @lexbuf.IStringLexbuf] token(lexbuf : T) -> (Token, Int, Int)  {
       }
     }
     22 => {
-      if _match_pattern >= 7 {
-        _match_pattern = 7
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 7
+      _match_end = lexbuf.curr_pos()
       break
     }
     23 => {
-      if _match_pattern >= 15 {
-        _match_pattern = 15
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 15
+      _match_end = lexbuf.curr_pos()
       break
     }
     24 => {
-      if _match_pattern >= 8 {
-        _match_pattern = 8
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 8
+      _match_end = lexbuf.curr_pos()
       break
     }
     25 => {
@@ -281,19 +237,15 @@ fn[T : @lexbuf.IStringLexbuf] token(lexbuf : T) -> (Token, Int, Int)  {
       }
     }
     27 => {
-      if _match_pattern >= 5 {
-        _match_pattern = 5
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 5
+      _match_end = lexbuf.curr_pos()
       break
     }
     28 => {
-      if _match_pattern >= 34 {
-        _match_pattern = 34
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 34
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         48..=57 => 19
         65..=90 => 19
@@ -305,12 +257,10 @@ fn[T : @lexbuf.IStringLexbuf] token(lexbuf : T) -> (Token, Int, Int)  {
       }
     }
     29 => {
-      if _match_pattern >= 34 {
-        _match_pattern = 34
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 34
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         48..=57 => 19
         65..=90 => 19
@@ -322,10 +272,8 @@ fn[T : @lexbuf.IStringLexbuf] token(lexbuf : T) -> (Token, Int, Int)  {
       }
     }
     30 => {
-      if _match_pattern >= 1 {
-        _match_pattern = 1
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 1
+      _match_end = lexbuf.curr_pos()
       continue match lexbuf.next_as_int() {
         0..=9 => 30
         10 => 43
@@ -393,21 +341,17 @@ fn[T : @lexbuf.IStringLexbuf] token(lexbuf : T) -> (Token, Int, Int)  {
       }
     }
     40 => {
-      if _match_pattern >= 22 {
-        _match_pattern = 22
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start + 1
-        _capture_0_end = _match_start + 2
-      }
+      _match_pattern = 22
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start + 1
+      _capture_0_end = _match_start + 2
       break
     }
     41 => {
-      if _match_pattern >= 34 {
-        _match_pattern = 34
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 34
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         48..=57 => 19
         65..=90 => 19
@@ -419,12 +363,10 @@ fn[T : @lexbuf.IStringLexbuf] token(lexbuf : T) -> (Token, Int, Int)  {
       }
     }
     42 => {
-      if _match_pattern >= 34 {
-        _match_pattern = 34
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 34
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         48..=57 => 19
         65..=90 => 19
@@ -436,10 +378,8 @@ fn[T : @lexbuf.IStringLexbuf] token(lexbuf : T) -> (Token, Int, Int)  {
       }
     }
     43 => {
-      if _match_pattern >= 1 {
-        _match_pattern = 1
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 1
+      _match_end = lexbuf.curr_pos()
       break
     }
     44 => {
@@ -467,61 +407,45 @@ fn[T : @lexbuf.IStringLexbuf] token(lexbuf : T) -> (Token, Int, Int)  {
       }
     }
     47 => {
-      if _match_pattern >= 29 {
-        _match_pattern = 29
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 29
+      _match_end = lexbuf.curr_pos()
       break
     }
     48 => {
-      if _match_pattern >= 28 {
-        _match_pattern = 28
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 28
+      _match_end = lexbuf.curr_pos()
       break
     }
     49 => {
-      if _match_pattern >= 27 {
-        _match_pattern = 27
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 27
+      _match_end = lexbuf.curr_pos()
       break
     }
     50 => {
-      if _match_pattern >= 26 {
-        _match_pattern = 26
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 26
+      _match_end = lexbuf.curr_pos()
       break
     }
     51 => {
-      if _match_pattern >= 25 {
-        _match_pattern = 25
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 25
+      _match_end = lexbuf.curr_pos()
       break
     }
     52 => {
-      if _match_pattern >= 24 {
-        _match_pattern = 24
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 24
+      _match_end = lexbuf.curr_pos()
       break
     }
     53 => {
-      if _match_pattern >= 23 {
-        _match_pattern = 23
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 23
+      _match_end = lexbuf.curr_pos()
       break
     }
     54 => {
-      if _match_pattern >= 34 {
-        _match_pattern = 34
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 34
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         48..=57 => 19
         65..=90 => 19
@@ -533,12 +457,10 @@ fn[T : @lexbuf.IStringLexbuf] token(lexbuf : T) -> (Token, Int, Int)  {
       }
     }
     55 => {
-      if _match_pattern >= 34 {
-        _match_pattern = 34
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 34
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         9..=10 => 60
         13 => 60
@@ -574,12 +496,10 @@ fn[T : @lexbuf.IStringLexbuf] token(lexbuf : T) -> (Token, Int, Int)  {
       }
     }
     59 => {
-      if _match_pattern >= 34 {
-        _match_pattern = 34
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 34
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         9..=10 => 64
         13 => 64
@@ -618,12 +538,10 @@ fn[T : @lexbuf.IStringLexbuf] token(lexbuf : T) -> (Token, Int, Int)  {
       }
     }
     63 => {
-      if _match_pattern >= 30 {
-        _match_pattern = 30
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start + 3
-        _capture_0_end = _match_start + 5
-      }
+      _match_pattern = 30
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start + 3
+      _capture_0_end = _match_start + 5
       break
     }
     64 => {
@@ -636,10 +554,8 @@ fn[T : @lexbuf.IStringLexbuf] token(lexbuf : T) -> (Token, Int, Int)  {
       }
     }
     65 => {
-      if _match_pattern >= 4 {
-        _match_pattern = 4
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 4
+      _match_end = lexbuf.curr_pos()
       break
     }
     66 => {
@@ -658,12 +574,10 @@ fn[T : @lexbuf.IStringLexbuf] token(lexbuf : T) -> (Token, Int, Int)  {
       }
     }
     67 => {
-      if _match_pattern >= 32 {
-        _match_pattern = 32
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start + 4
-        _capture_0_end = _match_end + -2
-      }
+      _match_pattern = 32
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start + 4
+      _capture_0_end = _match_end + -2
       break
     }
     68 => {
@@ -712,12 +626,10 @@ fn[T : @lexbuf.IStringLexbuf] token(lexbuf : T) -> (Token, Int, Int)  {
       }
     }
     71 => {
-      if _match_pattern >= 31 {
-        _match_pattern = 31
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start + 3
-        _capture_0_end = _match_start + 7
-      }
+      _match_pattern = 31
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start + 3
+      _capture_0_end = _match_start + 7
       break
     }
     72 => {
@@ -737,26 +649,22 @@ fn[T : @lexbuf.IStringLexbuf] token(lexbuf : T) -> (Token, Int, Int)  {
       }
     }
     73 => {
-      if _match_pattern >= 3 {
-        _match_pattern = 3
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _tag_0
-        _capture_0_end = _tag_1
-        _capture_1_start = _tag_0
-        _capture_1_end = _tag_2
-      }
+      _match_pattern = 3
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _tag_0
+      _capture_0_end = _tag_1
+      _capture_1_start = _tag_0
+      _capture_1_end = _tag_2
       break
     }
     74 => {
       _tag_1 = _tag_1_1
-      if _match_pattern >= 3 {
-        _match_pattern = 3
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _tag_0
-        _capture_0_end = _tag_1_1
-        _capture_1_start = _tag_0
-        _capture_1_end = _tag_2
-      }
+      _match_pattern = 3
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _tag_0
+      _capture_0_end = _tag_1_1
+      _capture_1_start = _tag_0
+      _capture_1_end = _tag_2
       break
     }
     _ => panic()
@@ -969,35 +877,27 @@ fn[T : @lexbuf.IStringLexbuf] string_inner_rquote(buffer : StringBuilder, lexbuf
       }
     }
     1 => {
-      if _match_pattern >= 12 {
-        _match_pattern = 12
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 12
+      _match_end = lexbuf.curr_pos()
       break
     }
     2 => {
-      if _match_pattern >= 11 {
-        _match_pattern = 11
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 1
-      }
+      _match_pattern = 11
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 1
       break
     }
     3 => {
-      if _match_pattern >= 0 {
-        _match_pattern = 0
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 0
+      _match_end = lexbuf.curr_pos()
       break
     }
     4 => {
-      if _match_pattern >= 11 {
-        _match_pattern = 11
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 1
-      }
+      _match_pattern = 11
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 1
       continue match lexbuf.next_as_int() {
         34 => 5
         92 => 6
@@ -1012,45 +912,33 @@ fn[T : @lexbuf.IStringLexbuf] string_inner_rquote(buffer : StringBuilder, lexbuf
       }
     }
     5 => {
-      if _match_pattern >= 7 {
-        _match_pattern = 7
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 7
+      _match_end = lexbuf.curr_pos()
       break
     }
     6 => {
-      if _match_pattern >= 6 {
-        _match_pattern = 6
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 6
+      _match_end = lexbuf.curr_pos()
       break
     }
     7 => {
-      if _match_pattern >= 1 {
-        _match_pattern = 1
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 1
+      _match_end = lexbuf.curr_pos()
       break
     }
     8 => {
-      if _match_pattern >= 5 {
-        _match_pattern = 5
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 5
+      _match_end = lexbuf.curr_pos()
       break
     }
     9 => {
-      if _match_pattern >= 4 {
-        _match_pattern = 4
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 4
+      _match_end = lexbuf.curr_pos()
       break
     }
     10 => {
-      if _match_pattern >= 2 {
-        _match_pattern = 2
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 2
+      _match_end = lexbuf.curr_pos()
       break
     }
     11 => {
@@ -1063,10 +951,8 @@ fn[T : @lexbuf.IStringLexbuf] string_inner_rquote(buffer : StringBuilder, lexbuf
       }
     }
     12 => {
-      if _match_pattern >= 3 {
-        _match_pattern = 3
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 3
+      _match_end = lexbuf.curr_pos()
       break
     }
     13 => {
@@ -1139,21 +1025,17 @@ fn[T : @lexbuf.IStringLexbuf] string_inner_rquote(buffer : StringBuilder, lexbuf
       }
     }
     22 => {
-      if _match_pattern >= 8 {
-        _match_pattern = 8
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start + 2
-        _capture_0_end = _match_start + 4
-      }
+      _match_pattern = 8
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start + 2
+      _capture_0_end = _match_start + 4
       break
     }
     23 => {
-      if _match_pattern >= 10 {
-        _match_pattern = 10
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start + 3
-        _capture_0_end = _match_end + -2
-      }
+      _match_pattern = 10
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start + 3
+      _capture_0_end = _match_end + -2
       break
     }
     24 => {
@@ -1163,12 +1045,10 @@ fn[T : @lexbuf.IStringLexbuf] string_inner_rquote(buffer : StringBuilder, lexbuf
       }
     }
     25 => {
-      if _match_pattern >= 9 {
-        _match_pattern = 9
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start + 2
-        _capture_0_end = _match_start + 6
-      }
+      _match_pattern = 9
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start + 2
+      _capture_0_end = _match_start + 6
       break
     }
     _ => panic()
@@ -1306,28 +1186,22 @@ fn[T : @lexbuf.IStringLexbuf] code_rbrace(buffer : StringBuilder, lexbuf : T) ->
       }
     }
     1 => {
-      if _match_pattern >= 6 {
-        _match_pattern = 6
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 6
+      _match_end = lexbuf.curr_pos()
       break
     }
     2 => {
-      if _match_pattern >= 5 {
-        _match_pattern = 5
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 1
-      }
+      _match_pattern = 5
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 1
       break
     }
     3 => {
-      if _match_pattern >= 5 {
-        _match_pattern = 5
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 1
-      }
+      _match_pattern = 5
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 1
       continue match lexbuf.next_as_int() {
         0..=33 => 9
         34 => 10
@@ -1338,12 +1212,10 @@ fn[T : @lexbuf.IStringLexbuf] code_rbrace(buffer : StringBuilder, lexbuf : T) ->
       }
     }
     4 => {
-      if _match_pattern >= 5 {
-        _match_pattern = 5
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 1
-      }
+      _match_pattern = 5
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 1
       continue match lexbuf.next_as_int() {
         0..=38 => 8
         40..=91 => 8
@@ -1352,29 +1224,23 @@ fn[T : @lexbuf.IStringLexbuf] code_rbrace(buffer : StringBuilder, lexbuf : T) ->
       }
     }
     5 => {
-      if _match_pattern >= 5 {
-        _match_pattern = 5
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 1
-      }
+      _match_pattern = 5
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 1
       continue match lexbuf.next_as_int() {
         47 => 12
         _ => break
       }
     }
     6 => {
-      if _match_pattern >= 3 {
-        _match_pattern = 3
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 3
+      _match_end = lexbuf.curr_pos()
       break
     }
     7 => {
-      if _match_pattern >= 4 {
-        _match_pattern = 4
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 4
+      _match_end = lexbuf.curr_pos()
       break
     }
     8 => {
@@ -1394,12 +1260,10 @@ fn[T : @lexbuf.IStringLexbuf] code_rbrace(buffer : StringBuilder, lexbuf : T) ->
       }
     }
     10 => {
-      if _match_pattern >= 1 {
-        _match_pattern = 1
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 1
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       break
     }
     11 => {
@@ -1416,12 +1280,10 @@ fn[T : @lexbuf.IStringLexbuf] code_rbrace(buffer : StringBuilder, lexbuf : T) ->
       }
     }
     13 => {
-      if _match_pattern >= 2 {
-        _match_pattern = 2
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 3
-      }
+      _match_pattern = 2
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 3
       break
     }
     14 => {
@@ -1433,12 +1295,10 @@ fn[T : @lexbuf.IStringLexbuf] code_rbrace(buffer : StringBuilder, lexbuf : T) ->
       }
     }
     15 => {
-      if _match_pattern >= 0 {
-        _match_pattern = 0
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 0
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       break
     }
     _ => panic()

--- a/src/tests/bytes_test/bytes.mbt
+++ b/src/tests/bytes_test/bytes.mbt
@@ -31,53 +31,41 @@ fn lex_utf8(lexbuf : @lexbuf.T, buf : StringBuilder) -> Unit raise MalformedUtf8
       }
     }
     1 => {
-      if _match_pattern >= 0 {
-        _match_pattern = 0
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 0
+      _match_end = lexbuf.curr_pos()
       break
     }
     2 => {
-      if _match_pattern >= 1 {
-        _match_pattern = 1
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 1
-      }
+      _match_pattern = 1
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 1
       break
     }
     3 => {
-      if _match_pattern >= 5 {
-        _match_pattern = 5
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 5
+      _match_end = lexbuf.curr_pos()
       break
     }
     4 => {
-      if _match_pattern >= 5 {
-        _match_pattern = 5
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 5
+      _match_end = lexbuf.curr_pos()
       continue match lexbuf.next_as_int() {
         128..=191 => 9
         _ => break
       }
     }
     5 => {
-      if _match_pattern >= 5 {
-        _match_pattern = 5
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 5
+      _match_end = lexbuf.curr_pos()
       continue match lexbuf.next_as_int() {
         128..=191 => 8
         _ => break
       }
     }
     6 => {
-      if _match_pattern >= 5 {
-        _match_pattern = 5
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 5
+      _match_end = lexbuf.curr_pos()
       continue match lexbuf.next_as_int() {
         128..=191 => 7
         _ => break
@@ -96,14 +84,12 @@ fn lex_utf8(lexbuf : @lexbuf.T, buf : StringBuilder) -> Unit raise MalformedUtf8
       }
     }
     9 => {
-      if _match_pattern >= 2 {
-        _match_pattern = 2
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 1
-        _capture_1_start = _match_start + 1
-        _capture_1_end = _match_start + 2
-      }
+      _match_pattern = 2
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 1
+      _capture_1_start = _match_start + 1
+      _capture_1_end = _match_start + 2
       break
     }
     10 => {
@@ -113,31 +99,27 @@ fn lex_utf8(lexbuf : @lexbuf.T, buf : StringBuilder) -> Unit raise MalformedUtf8
       }
     }
     11 => {
-      if _match_pattern >= 3 {
-        _match_pattern = 3
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 1
-        _capture_1_start = _match_start + 1
-        _capture_1_end = _match_start + 2
-        _capture_2_start = _match_start + 2
-        _capture_2_end = _match_start + 3
-      }
+      _match_pattern = 3
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 1
+      _capture_1_start = _match_start + 1
+      _capture_1_end = _match_start + 2
+      _capture_2_start = _match_start + 2
+      _capture_2_end = _match_start + 3
       break
     }
     12 => {
-      if _match_pattern >= 4 {
-        _match_pattern = 4
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 1
-        _capture_1_start = _match_start + 1
-        _capture_1_end = _match_start + 2
-        _capture_2_start = _match_start + 2
-        _capture_2_end = _match_start + 3
-        _capture_3_start = _match_start + 3
-        _capture_3_end = _match_start + 4
-      }
+      _match_pattern = 4
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 1
+      _capture_1_start = _match_start + 1
+      _capture_1_end = _match_start + 2
+      _capture_2_start = _match_start + 2
+      _capture_2_end = _match_start + 3
+      _capture_3_start = _match_start + 3
+      _capture_3_end = _match_start + 4
       break
     }
     _ => panic()

--- a/src/tests/bytes_unicode_test/bytes.mbt
+++ b/src/tests/bytes_unicode_test/bytes.mbt
@@ -25,10 +25,8 @@ fn lex_unicode(lexbuf : @lexbuf.T) -> Int  {
       }
     }
     1 => {
-      if _match_pattern >= 3 {
-        _match_pattern = 3
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 3
+      _match_end = lexbuf.curr_pos()
       break
     }
     2 => {
@@ -96,12 +94,10 @@ fn lex_unicode(lexbuf : @lexbuf.T) -> Int  {
       }
     }
     11 => {
-      if _match_pattern >= 2 {
-        _match_pattern = 2
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 3
-      }
+      _match_pattern = 2
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 3
       break
     }
     12 => {
@@ -113,20 +109,16 @@ fn lex_unicode(lexbuf : @lexbuf.T) -> Int  {
       }
     }
     13 => {
-      if _match_pattern >= 3 {
-        _match_pattern = 3
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 3
+      _match_end = lexbuf.curr_pos()
       continue match lexbuf.next_as_int() {
         231 => 15
         _ => break
       }
     }
     14 => {
-      if _match_pattern >= 1 {
-        _match_pattern = 1
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 1
+      _match_end = lexbuf.curr_pos()
       break
     }
     15 => {
@@ -178,10 +170,8 @@ fn lex_unicode(lexbuf : @lexbuf.T) -> Int  {
       }
     }
     23 => {
-      if _match_pattern >= 0 {
-        _match_pattern = 0
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 0
+      _match_end = lexbuf.curr_pos()
       break
     }
     _ => panic()

--- a/src/tests/eof_test/eof.mbt
+++ b/src/tests/eof_test/eof.mbt
@@ -25,34 +25,26 @@ fn[T : @lexbuf.IStringLexbuf] token(lexbuf : T) -> Token  {
       }
     }
     1 => {
-      if _match_pattern >= 3 {
-        _match_pattern = 3
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 3
+      _match_end = lexbuf.curr_pos()
       break
     }
     2 => {
-      if _match_pattern >= 2 {
-        _match_pattern = 2
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 2
+      _match_end = lexbuf.curr_pos()
       break
     }
     3 => {
-      if _match_pattern >= 1 {
-        _match_pattern = 1
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 1
+      _match_end = lexbuf.curr_pos()
       continue match lexbuf.next_as_int() {
         -1 => 4
         _ => break
       }
     }
     4 => {
-      if _match_pattern >= 0 {
-        _match_pattern = 0
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 0
+      _match_end = lexbuf.curr_pos()
       break
     }
     _ => panic()

--- a/src/tests/fortytwolexer/fortytwolexer.mbt
+++ b/src/tests/fortytwolexer/fortytwolexer.mbt
@@ -10,10 +10,8 @@ fn[T : @lexbuf.IStringLexbuf] scan_newline(lexbuf : T) -> Int  {
   let mut _capture_0_end = -1
   loop 0 {
     0 => {
-      if _match_pattern >= 2 {
-        _match_pattern = 2
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 2
+      _match_end = lexbuf.curr_pos()
       continue match lexbuf.next_as_int() {
         0..=9 => 1
         10 => 2
@@ -24,24 +22,18 @@ fn[T : @lexbuf.IStringLexbuf] scan_newline(lexbuf : T) -> Int  {
       }
     }
     1 => {
-      if _match_pattern >= 1 {
-        _match_pattern = 1
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 1
+      _match_end = lexbuf.curr_pos()
       break
     }
     2 => {
-      if _match_pattern >= 0 {
-        _match_pattern = 0
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 0
+      _match_end = lexbuf.curr_pos()
       break
     }
     3 => {
-      if _match_pattern >= 0 {
-        _match_pattern = 0
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 0
+      _match_end = lexbuf.curr_pos()
       continue match lexbuf.next_as_int() {
         10 => 2
         _ => break

--- a/src/tests/issue12/issue12.mbt
+++ b/src/tests/issue12/issue12.mbt
@@ -17,12 +17,10 @@ fn[T : @lexbuf.IStringLexbuf] test_func(lexbuf : T) -> String  {
       }
     }
     1 => {
-      if _match_pattern >= 0 {
-        _match_pattern = 0
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 0
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         97..=98 => 2
         _ => break
@@ -36,12 +34,10 @@ fn[T : @lexbuf.IStringLexbuf] test_func(lexbuf : T) -> String  {
       }
     }
     3 => {
-      if _match_pattern >= 0 {
-        _match_pattern = 0
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 0
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         97 => 3
         98 => 2

--- a/src/tests/jsonlexer/jsonlexer.mbt
+++ b/src/tests/jsonlexer/jsonlexer.mbt
@@ -32,10 +32,8 @@ fn[T : @lexbuf.IStringLexbuf] token(lexbuf : T) -> Token raise LexError  {
   let mut _capture_1_end = -1
   loop 0 {
     0 => {
-      if _match_pattern >= 13 {
-        _match_pattern = 13
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 13
+      _match_end = lexbuf.curr_pos()
       continue match lexbuf.next_as_int() {
         0..=8 => 1
         9..=10 => 2
@@ -71,44 +69,34 @@ fn[T : @lexbuf.IStringLexbuf] token(lexbuf : T) -> Token raise LexError  {
       }
     }
     1 => {
-      if _match_pattern >= 12 {
-        _match_pattern = 12
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 1
-      }
+      _match_pattern = 12
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 1
       break
     }
     2 => {
-      if _match_pattern >= 0 {
-        _match_pattern = 0
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 0
+      _match_end = lexbuf.curr_pos()
       break
     }
     3 => {
-      if _match_pattern >= 2 {
-        _match_pattern = 2
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 1
-      }
+      _match_pattern = 2
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 1
       break
     }
     4 => {
-      if _match_pattern >= 7 {
-        _match_pattern = 7
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 7
+      _match_end = lexbuf.curr_pos()
       break
     }
     5 => {
-      if _match_pattern >= 12 {
-        _match_pattern = 12
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 1
-      }
+      _match_pattern = 12
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 1
       continue match lexbuf.next_as_int() {
         48 => 6
         49..=57 => 7
@@ -116,12 +104,10 @@ fn[T : @lexbuf.IStringLexbuf] token(lexbuf : T) -> Token raise LexError  {
       }
     }
     6 => {
-      if _match_pattern >= 1 {
-        _match_pattern = 1
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 1
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         69 => 20
         101 => 20
@@ -129,12 +115,10 @@ fn[T : @lexbuf.IStringLexbuf] token(lexbuf : T) -> Token raise LexError  {
       }
     }
     7 => {
-      if _match_pattern >= 1 {
-        _match_pattern = 1
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 1
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         46 => 19
         48..=57 => 7
@@ -144,74 +128,58 @@ fn[T : @lexbuf.IStringLexbuf] token(lexbuf : T) -> Token raise LexError  {
       }
     }
     8 => {
-      if _match_pattern >= 8 {
-        _match_pattern = 8
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 8
+      _match_end = lexbuf.curr_pos()
       break
     }
     9 => {
-      if _match_pattern >= 5 {
-        _match_pattern = 5
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 5
+      _match_end = lexbuf.curr_pos()
       break
     }
     10 => {
-      if _match_pattern >= 6 {
-        _match_pattern = 6
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 6
+      _match_end = lexbuf.curr_pos()
       break
     }
     11 => {
-      if _match_pattern >= 12 {
-        _match_pattern = 12
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 1
-      }
+      _match_pattern = 12
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 1
       continue match lexbuf.next_as_int() {
         97 => 17
         _ => break
       }
     }
     12 => {
-      if _match_pattern >= 12 {
-        _match_pattern = 12
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 1
-      }
+      _match_pattern = 12
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 1
       continue match lexbuf.next_as_int() {
         117 => 16
         _ => break
       }
     }
     13 => {
-      if _match_pattern >= 12 {
-        _match_pattern = 12
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 1
-      }
+      _match_pattern = 12
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 1
       continue match lexbuf.next_as_int() {
         114 => 18
         _ => break
       }
     }
     14 => {
-      if _match_pattern >= 3 {
-        _match_pattern = 3
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 3
+      _match_end = lexbuf.curr_pos()
       break
     }
     15 => {
-      if _match_pattern >= 4 {
-        _match_pattern = 4
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 4
+      _match_end = lexbuf.curr_pos()
       break
     }
     16 => {
@@ -271,24 +239,20 @@ fn[T : @lexbuf.IStringLexbuf] token(lexbuf : T) -> Token raise LexError  {
       }
     }
     25 => {
-      if _match_pattern >= 1 {
-        _match_pattern = 1
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 1
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         48..=57 => 25
         _ => break
       }
     }
     26 => {
-      if _match_pattern >= 1 {
-        _match_pattern = 1
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 1
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         48..=57 => 26
         69 => 20
@@ -297,10 +261,8 @@ fn[T : @lexbuf.IStringLexbuf] token(lexbuf : T) -> Token raise LexError  {
       }
     }
     27 => {
-      if _match_pattern >= 11 {
-        _match_pattern = 11
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 11
+      _match_end = lexbuf.curr_pos()
       break
     }
     28 => {
@@ -310,17 +272,13 @@ fn[T : @lexbuf.IStringLexbuf] token(lexbuf : T) -> Token raise LexError  {
       }
     }
     29 => {
-      if _match_pattern >= 9 {
-        _match_pattern = 9
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 9
+      _match_end = lexbuf.curr_pos()
       break
     }
     30 => {
-      if _match_pattern >= 10 {
-        _match_pattern = 10
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 10
+      _match_end = lexbuf.curr_pos()
       break
     }
     _ => panic()
@@ -413,10 +371,8 @@ fn[T : @lexbuf.IStringLexbuf] lex_string(buf : StringBuilder, lexbuf : T) -> Uni
   let mut _capture_1_end = -1
   loop 0 {
     0 => {
-      if _match_pattern >= 4 {
-        _match_pattern = 4
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 4
+      _match_end = lexbuf.curr_pos()
       continue match lexbuf.next_as_int() {
         0..=31 => 1
         32..=33 => 2
@@ -430,39 +386,31 @@ fn[T : @lexbuf.IStringLexbuf] lex_string(buf : StringBuilder, lexbuf : T) -> Uni
       }
     }
     1 => {
-      if _match_pattern >= 3 {
-        _match_pattern = 3
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 1
-      }
+      _match_pattern = 3
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 1
       break
     }
     2 => {
-      if _match_pattern >= 2 {
-        _match_pattern = 2
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 1
-      }
+      _match_pattern = 2
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 1
       break
     }
     3 => {
-      if _match_pattern >= 0 {
-        _match_pattern = 0
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 1
-      }
+      _match_pattern = 0
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 1
       break
     }
     4 => {
-      if _match_pattern >= 3 {
-        _match_pattern = 3
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_start + 1
-      }
+      _match_pattern = 3
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_start + 1
       continue match lexbuf.next_as_int() {
         34 => 5
         47 => 5
@@ -477,12 +425,10 @@ fn[T : @lexbuf.IStringLexbuf] lex_string(buf : StringBuilder, lexbuf : T) -> Uni
       }
     }
     5 => {
-      if _match_pattern >= 1 {
-        _match_pattern = 1
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 1
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       break
     }
     6 => {

--- a/src/tests/longest_match/longest_match.mbt
+++ b/src/tests/longest_match/longest_match.mbt
@@ -19,10 +19,8 @@ fn[T : @lexbuf.IStringLexbuf] token(lexbuf : T) -> String  {
       }
     }
     1 => {
-      if _match_pattern >= 1 {
-        _match_pattern = 1
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 1
+      _match_end = lexbuf.curr_pos()
       continue match lexbuf.next_as_int() {
         48..=57 => 1
         65..=90 => 1
@@ -32,10 +30,8 @@ fn[T : @lexbuf.IStringLexbuf] token(lexbuf : T) -> String  {
       }
     }
     2 => {
-      if _match_pattern >= 1 {
-        _match_pattern = 1
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 1
+      _match_end = lexbuf.curr_pos()
       continue match lexbuf.next_as_int() {
         48..=57 => 1
         65..=90 => 1
@@ -47,10 +43,8 @@ fn[T : @lexbuf.IStringLexbuf] token(lexbuf : T) -> String  {
       }
     }
     3 => {
-      if _match_pattern >= 1 {
-        _match_pattern = 1
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 1
+      _match_end = lexbuf.curr_pos()
       continue match lexbuf.next_as_int() {
         48..=57 => 1
         65..=90 => 1
@@ -62,10 +56,8 @@ fn[T : @lexbuf.IStringLexbuf] token(lexbuf : T) -> String  {
       }
     }
     4 => {
-      if _match_pattern >= 0 {
-        _match_pattern = 0
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 0
+      _match_end = lexbuf.curr_pos()
       continue match lexbuf.next_as_int() {
         48..=57 => 1
         65..=90 => 1

--- a/src/tests/longest_match/longest_match.mbt
+++ b/src/tests/longest_match/longest_match.mbt
@@ -1,0 +1,100 @@
+
+
+fn[T : @lexbuf.IStringLexbuf] token(lexbuf : T) -> String  {
+  // The matched pattern id
+  let mut _match_pattern = @int.max_value
+  let mut _match_start = lexbuf.curr_pos()
+  let mut _match_end = -1
+  let mut _capture_0_start = -1
+  let mut _capture_0_end = -1
+  loop 0 {
+    0 => {
+      continue match lexbuf.next_as_int() {
+        65..=90 => 1
+        95 => 1
+        97..=107 => 1
+        108 => 2
+        109..=122 => 1
+        _ => break
+      }
+    }
+    1 => {
+      if _match_pattern >= 1 {
+        _match_pattern = 1
+        _match_end = lexbuf.curr_pos()
+      }
+      continue match lexbuf.next_as_int() {
+        48..=57 => 1
+        65..=90 => 1
+        95 => 1
+        97..=122 => 1
+        _ => break
+      }
+    }
+    2 => {
+      if _match_pattern >= 1 {
+        _match_pattern = 1
+        _match_end = lexbuf.curr_pos()
+      }
+      continue match lexbuf.next_as_int() {
+        48..=57 => 1
+        65..=90 => 1
+        95 => 1
+        97..=100 => 1
+        101 => 3
+        102..=122 => 1
+        _ => break
+      }
+    }
+    3 => {
+      if _match_pattern >= 1 {
+        _match_pattern = 1
+        _match_end = lexbuf.curr_pos()
+      }
+      continue match lexbuf.next_as_int() {
+        48..=57 => 1
+        65..=90 => 1
+        95 => 1
+        97..=115 => 1
+        116 => 4
+        117..=122 => 1
+        _ => break
+      }
+    }
+    4 => {
+      if _match_pattern >= 0 {
+        _match_pattern = 0
+        _match_end = lexbuf.curr_pos()
+      }
+      continue match lexbuf.next_as_int() {
+        48..=57 => 1
+        65..=90 => 1
+        95 => 1
+        97..=122 => 1
+        _ => break
+      }
+    }
+    _ => panic()
+  }
+
+  guard _match_pattern <= 1 else {
+    // No pattern matched
+    panic()
+  }
+
+  lexbuf.reset(pos=_match_end)
+  match _match_pattern {
+    0 => {
+      ()
+ "keyword" 
+    }
+    1 => {
+      ()
+ "ident" 
+    }
+    _ => panic()
+  }
+}
+
+
+

--- a/src/tests/longest_match/longest_match.mbtx
+++ b/src/tests/longest_match/longest_match.mbtx
@@ -1,0 +1,12 @@
+{}
+
+regex ident = ['a'-'z' 'A'-'Z' '_'] ['a'-'z' 'A'-'Z' '_' '0'-'9']*;
+
+rule token[T : @lexbuf.IStringLexbuf](lexbuf : T) -> String {
+    parse {
+        "let" => { "keyword" }
+        ident => { "ident" }
+    }
+}
+
+{}

--- a/src/tests/longest_match/longest_match_wbtest.mbt
+++ b/src/tests/longest_match/longest_match_wbtest.mbt
@@ -2,6 +2,5 @@
 test {
   inspect(token(@lexbuf.StringLexbuf::from_string("le")), content="ident")
   inspect(token(@lexbuf.StringLexbuf::from_string("let")), content="keyword")
-  // FIXME:
-  inspect(token(@lexbuf.StringLexbuf::from_string("letx")), content="keyword")
+  inspect(token(@lexbuf.StringLexbuf::from_string("letx")), content="ident")
 }

--- a/src/tests/longest_match/longest_match_wbtest.mbt
+++ b/src/tests/longest_match/longest_match_wbtest.mbt
@@ -1,0 +1,7 @@
+///|
+test {
+  inspect(token(@lexbuf.StringLexbuf::from_string("le")), content="ident")
+  inspect(token(@lexbuf.StringLexbuf::from_string("let")), content="keyword")
+  // FIXME:
+  inspect(token(@lexbuf.StringLexbuf::from_string("letx")), content="keyword")
+}

--- a/src/tests/longest_match/moon.pkg.json
+++ b/src/tests/longest_match/moon.pkg.json
@@ -1,0 +1,13 @@
+{
+    "pre-build": [
+        {
+            "command": "node $mod_dir/boot/snapshot/moonlex.js $input -o $output",
+            "input": "longest_match.mbtx",
+            "output": "longest_match.mbt"
+        }
+    ],
+    "warn-list": "-1-13",
+    "import": [
+        "moonbitlang/ulex-runtime/lexbuf"
+    ]
+}

--- a/src/tests/named_regexes/named_regexes.mbt
+++ b/src/tests/named_regexes/named_regexes.mbt
@@ -18,24 +18,18 @@ fn[T : @lexbuf.IStringLexbuf] lex_is_number(lexbuf : T) -> Bool  {
       }
     }
     1 => {
-      if _match_pattern >= 1 {
-        _match_pattern = 1
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 1
+      _match_end = lexbuf.curr_pos()
       break
     }
     2 => {
-      if _match_pattern >= 0 {
-        _match_pattern = 0
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 0
+      _match_end = lexbuf.curr_pos()
       break
     }
     3 => {
-      if _match_pattern >= 0 {
-        _match_pattern = 0
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 0
+      _match_end = lexbuf.curr_pos()
       continue match lexbuf.next_as_int() {
         48..=57 => 3
         _ => break

--- a/src/tests/unicode_test/unicode.mbt
+++ b/src/tests/unicode_test/unicode.mbt
@@ -23,34 +23,26 @@ fn[T : @lexbuf.IStringLexbuf] lex_unicode(lexbuf : T) -> Int  {
       }
     }
     1 => {
-      if _match_pattern >= 3 {
-        _match_pattern = 3
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 3
+      _match_end = lexbuf.curr_pos()
       break
     }
     2 => {
-      if _match_pattern >= 2 {
-        _match_pattern = 2
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 2
+      _match_end = lexbuf.curr_pos()
       break
     }
     3 => {
-      if _match_pattern >= 3 {
-        _match_pattern = 3
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 3
+      _match_end = lexbuf.curr_pos()
       continue match lexbuf.next_as_int() {
         29233 => 5
         _ => break
       }
     }
     4 => {
-      if _match_pattern >= 1 {
-        _match_pattern = 1
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 1
+      _match_end = lexbuf.curr_pos()
       break
     }
     5 => {
@@ -66,10 +58,8 @@ fn[T : @lexbuf.IStringLexbuf] lex_unicode(lexbuf : T) -> Int  {
       }
     }
     7 => {
-      if _match_pattern >= 0 {
-        _match_pattern = 0
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 0
+      _match_end = lexbuf.curr_pos()
       break
     }
     _ => panic()

--- a/src/tests/wordcountlexer/wordcountlexer.mbt
+++ b/src/tests/wordcountlexer/wordcountlexer.mbt
@@ -13,10 +13,8 @@ fn[T : @lexbuf.IStringLexbuf] count(lines : Int, words : Int, chars : Int, lexbu
   let mut _capture_1_end = -1
   loop 0 {
     0 => {
-      if _match_pattern >= 3 {
-        _match_pattern = 3
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 3
+      _match_end = lexbuf.curr_pos()
       continue match lexbuf.next_as_int() {
         0..=8 => 1
         9 => 2
@@ -28,12 +26,10 @@ fn[T : @lexbuf.IStringLexbuf] count(lines : Int, words : Int, chars : Int, lexbu
       }
     }
     1 => {
-      if _match_pattern >= 1 {
-        _match_pattern = 1
-        _match_end = lexbuf.curr_pos()
-        _capture_0_start = _match_start
-        _capture_0_end = _match_end
-      }
+      _match_pattern = 1
+      _match_end = lexbuf.curr_pos()
+      _capture_0_start = _match_start
+      _capture_0_end = _match_end
       continue match lexbuf.next_as_int() {
         0..=8 => 1
         11..=31 => 1
@@ -42,17 +38,13 @@ fn[T : @lexbuf.IStringLexbuf] count(lines : Int, words : Int, chars : Int, lexbu
       }
     }
     2 => {
-      if _match_pattern >= 2 {
-        _match_pattern = 2
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 2
+      _match_end = lexbuf.curr_pos()
       break
     }
     3 => {
-      if _match_pattern >= 0 {
-        _match_pattern = 0
-        _match_end = lexbuf.curr_pos()
-      }
+      _match_pattern = 0
+      _match_end = lexbuf.curr_pos()
       break
     }
     _ => panic()


### PR DESCRIPTION
Closes #48 

This PR make default policy to longest match. So that:

Given:
```
regex ident = ['a'-'z' 'A'-'Z' '_'] ['a'-'z' 'A'-'Z' '_' '0'-'9']*;

rule token[T : @lexbuf.IStringLexbuf](lexbuf : T) -> String {
    parse {
        "let" => { "keyword" }
        ident => { "ident" }
    }
}
```

```
test {
  inspect(token(@lexbuf.StringLexbuf::from_string("le")), content="ident")
  inspect(token(@lexbuf.StringLexbuf::from_string("let")), content="keyword")
  inspect(token(@lexbuf.StringLexbuf::from_string("letx")), content="ident")
}
```
works.